### PR TITLE
Finish work needed to use webhookdb as a gem in a deployable repo

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -6,55 +6,5 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "appydays/dotenviable"
 Appydays::Dotenviable.load
 
-require "webhookdb"
-require "pry/clipboard"
-
-Pry.config.commands.alias_command "ch", "copy-history"
-Pry.config.commands.alias_command "cr", "copy-result"
-
-# Decode the given cookie string. Since cookies are encrypted,
-# this is useful for debugging what they contain.
-def decode_cookie(s)
-  require "webhookdb/service"
-  return Webhookdb::Service.decode_cookie(s)
-end
-
-# Connect this session of Pry to the database.
-# It also registers subscribers, so changes to the models are handled
-# by their correct async jobs (since async jobs are handled in-process).
-def connect
-  require "webhookdb"
-  Webhookdb.load_app
-  Webhookdb::Async.setup_web if Amigo.subscribers.empty?
-  return
-end
-
-def copt
-  rc = Appydays::Loggable[self].silence(:fatal) do
-    Webhookdb::Customer::ResetCode.order(:id).last
-  end
-  tok = rc.token
-  Clipboard.copy tok
-  puts "Copied OTP #{tok} for #{rc.customer.email} to clipboard"
-  return tok
-end
-
-# Load models and fixtures. Use this when riffing locally.
-def repl
-  require "webhookdb"
-  Webhookdb.load_app
-  require "webhookdb/fixtures"
-  Webhookdb::Fixtures.load_all
-  return
-end
-
-def console
-  connect
-  require "webhookdb/console"
-  Webhookdb::Console.enable_safe_mode
-  self.extend Webhookdb::Console::MainMethods
-  Amigo.register_subscriber do |ev|
-    Webhookdb::Console.console_logger(ev)
-  end
-  return
-end
+require "webhookdb/pry"
+Webhookdb::Pry.setup(self)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to WebhookDB will be described in this file,
+include new integerations and features.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [1.0.0] - 2024-01-08
+
+Initial open-source release of WebhookDB. WebhookDB has been used in production
+since 2021, so the changelog will start from this point forward.

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "ice_cube", git: "https://github.com/nehresma/ice_cube.git", ref: "d7ea51efc
 
 # NOTE: When running integration tests, you will need to set BUNDLE_WITHOUT to something other than 'test'.
 group :test do
-  gem "clipboard", "~> 1.3"
   gem "faker", "~> 3.2"
   gem "fluent_fixtures", "~> 0.11"
   gem "rack-test", "~> 2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
       barnes (~> 0.0)
       bcrypt (~> 3.1)
       biz (~> 1.8)
+      clipboard (~> 1.3)
       concurrent-ruby (~> 1.2)
       down (~> 5.4)
       foreman (~> 0.87)
@@ -380,7 +381,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  clipboard (~> 1.3)
   faker (~> 3.2)
   fluent_fixtures (~> 0.11)
   ice_cube!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    webhookdb (0.1.1)
+    webhookdb (1.0.0)
       activesupport (~> 7.1)
       appydays (>= 0.8)
       aws-sdk-pricing (~> 1.53)
@@ -316,10 +316,10 @@ GEM
     ruby2_keywords (0.0.5)
     semantic_logger (4.15.0)
       concurrent-ruby (~> 1.0)
-    sentry-ruby (5.15.2)
+    sentry-ruby (5.16.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.15.2)
-      sentry-ruby (~> 5.15.2)
+    sentry-sidekiq (5.16.0)
+      sentry-ruby (~> 5.16.0)
       sidekiq (>= 3.0)
     sequel (5.76.0)
       bigdecimal

--- a/Rakefile
+++ b/Rakefile
@@ -8,23 +8,5 @@ Appydays::Dotenviable.load
 
 require "sentry-ruby"
 
-require "webhookdb/tasks/admin"
-Webhookdb::Tasks::Admin.new
-require "webhookdb/tasks/annotate"
-Webhookdb::Tasks::Annotate.new
-require "webhookdb/tasks/db"
-Webhookdb::Tasks::DB.new
-require "webhookdb/tasks/docs"
-Webhookdb::Tasks::Docs.new
-require "webhookdb/tasks/fixture"
-Webhookdb::Tasks::Fixture.new
-require "webhookdb/tasks/release"
-Webhookdb::Tasks::Release.new
-require "webhookdb/tasks/message"
-Webhookdb::Tasks::Message.new
-require "webhookdb/tasks/regress"
-Webhookdb::Tasks::Regress.new
-require "webhookdb/tasks/sidekiq"
-Webhookdb::Tasks::Sidekiq.new
-require "webhookdb/tasks/specs"
-Webhookdb::Tasks::Specs.new
+require "webhookdb/tasks"
+Webhookdb::Tasks.load_all

--- a/config.ru
+++ b/config.ru
@@ -7,15 +7,4 @@ require "webhookdb"
 Webhookdb.load_app
 
 require "webhookdb/apps"
-Webhookdb::Async.setup_web
-
-map "/admin" do
-  run Webhookdb::Apps::AdminAPI.build_app
-end
-map "/sidekiq" do
-  run Webhookdb::Apps::SidekiqWeb.to_app
-end
-map "/terminal" do
-  run Webhookdb::Apps::Webterm.to_app
-end
-run Webhookdb::Apps::API.build_app
+Webhookdb::Apps.rack_up(self)

--- a/integration/service_integrations_spec.rb
+++ b/integration/service_integrations_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "service integrations", :integration do
     expect(resp).to party_status(202)
     expect(resp).to party_response(match(o: "k"))
     logged_whs = Webhookdb::LoggedWebhook.where(service_integration_opaque_id: sint.opaque_id).all
-    expect(logged_whs).to have_length(be_positive)
+    expect(logged_whs).to_not be_empty
   end
 
   it "can upsert data synchrononously through endpoint" do

--- a/lib/webhookdb.rb
+++ b/lib/webhookdb.rb
@@ -54,6 +54,7 @@ module Webhookdb
   RELEASE = ENV.fetch("HEROKU_RELEASE_VERSION", "unknown-release")
   RELEASE_CREATED_AT = ENV.fetch("HEROKU_RELEASE_CREATED_AT") { Time.at(0).utc.iso8601 }
   INTEGRATION_TESTS_ENABLED = ENV.fetch("INTEGRATION_TESTS", false)
+  require "webhookdb/version"
 
   DATA_DIR = Pathname(__FILE__).dirname.parent + "data"
 

--- a/lib/webhookdb/api/system.rb
+++ b/lib/webhookdb/api/system.rb
@@ -13,7 +13,10 @@ class Webhookdb::API::System < Webhookdb::Service
   helpers Webhookdb::Service::Helpers
 
   get :healthz do
-    Webhookdb::Postgres::Model.db.execute("SELECT 1=1")
+    # Do not bother looking at dependencies like databases.
+    # If the primary is down, we can still accept webhooks
+    # if LoggedWebhook resiliency is configured,
+    # which is the primary thing about whether we're healthy or not.
     status 200
     {o: "k"}
   end
@@ -29,9 +32,11 @@ class Webhookdb::API::System < Webhookdb::Service
     }
   end
 
-  resource :debug do
-    get :echo do
-      pp params.to_h
+  if ["development", "test"].include?(Webhookdb::RACK_ENV)
+    resource :debug do
+      get :echo do
+        pp params.to_h
+      end
     end
   end
 end

--- a/lib/webhookdb/pry.rb
+++ b/lib/webhookdb/pry.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "webhookdb"
+
+module Webhookdb::Pry
+  # Call this from .pryrc.
+  #
+  # @example
+  # lib = File.expand_path("lib", __dir__)
+  # $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+  #
+  # require "appydays/dotenviable"
+  # Appydays::Dotenviable.load
+  #
+  # require "webhookdb/pry"
+  # Webhookdb::Pry.setup(self)
+  def self.setup(main)
+    main.instance_exec do
+      require "pry/clipboard"
+
+      Pry.config.commands.alias_command "ch", "copy-history"
+      Pry.config.commands.alias_command "cr", "copy-result"
+
+      # Decode the given cookie string. Since cookies are encrypted,
+      # this is useful for debugging what they contain.
+      def decode_cookie(s)
+        require "webhookdb/service"
+        return Webhookdb::Service.decode_cookie(s)
+      end
+
+      # Connect this session of Pry to the database.
+      # It also registers subscribers, so changes to the models are handled
+      # by their correct async jobs (since async jobs are handled in-process).
+      def connect
+        require "webhookdb"
+        Webhookdb.load_app
+        Webhookdb::Async.setup_web if Amigo.subscribers.empty?
+        return
+      end
+
+      def copt
+        rc = Appydays::Loggable[self].silence(:fatal) do
+          Webhookdb::Customer::ResetCode.order(:id).last
+        end
+        tok = rc.token
+        Clipboard.copy tok
+        puts "Copied OTP #{tok} for #{rc.customer.email} to clipboard"
+        return tok
+      end
+
+      # Load models and fixtures. Use this when riffing locally.
+      def repl
+        require "webhookdb"
+        Webhookdb.load_app
+        require "webhookdb/fixtures"
+        Webhookdb::Fixtures.load_all
+        return
+      end
+
+      def console
+        connect
+        require "webhookdb/console"
+        Webhookdb::Console.enable_safe_mode
+        self.extend Webhookdb::Console::MainMethods
+        Amigo.register_subscriber do |ev|
+          Webhookdb::Console.console_logger(ev)
+        end
+        return
+      end
+    end
+  end
+end

--- a/lib/webhookdb/replicator.rb
+++ b/lib/webhookdb/replicator.rb
@@ -79,6 +79,8 @@ class Webhookdb::Replicator
     # Is this an enterprise-only replicator?
     attr_reader :enterprise
 
+    def documentable? = @documentable
+
     def initialize(
       name:,
       ctor:,
@@ -91,7 +93,8 @@ class Webhookdb::Replicator
       api_docs_url: "",
       description: nil,
       enterprise: false,
-      documentation_url: nil
+      documentation_url: nil,
+      documentable: nil
     )
       raise ArgumentError, "must support one or both of webhooks and backfill" unless
         supports_webhooks || supports_backfill
@@ -109,7 +112,7 @@ class Webhookdb::Replicator
       @ctor = ctor.is_a?(Class) ? ctor.method(:new) : ctor
       @resource_name_plural = resource_name_plural || "#{self.resource_name_singular}s"
       @description = description || "Replicate #{self.resource_name_plural} into your database."
-      self.feature_roles
+      @documentable = documentable.nil? ? !self.name.start_with?("webhookdb_", "fake_", "theranest_") : documentable
     end
 
     def inspect

--- a/lib/webhookdb/replicator/docgen.rb
+++ b/lib/webhookdb/replicator/docgen.rb
@@ -3,9 +3,10 @@
 # Write docs for docs.webhookdb.com Jekyll site.
 class Webhookdb::Replicator::Docgen
   def self.documentable_descriptors
-    return Webhookdb::Replicator.registry.values.reject do |repl|
-      repl.name.start_with?("webhookdb_", "fake_")
-    end.sort_by(&:name)
+    return Webhookdb::Replicator.registry.
+        values.
+        select(&:documentable?).
+        sort_by(&:name)
   end
 
   # @!attribute desc

--- a/lib/webhookdb/spec_helpers/integration.rb
+++ b/lib/webhookdb/spec_helpers/integration.rb
@@ -26,12 +26,12 @@ module Webhookdb::IntegrationSpecHelpers
         example.metadata[:integration]
 
       @to_destroy = []
-      WebMock.allow_net_connect!
+      WebMock.allow_net_connect! if defined?(WebMock)
     end
 
     context.after(:each) do
       @to_destroy.each(&:destroy)
-      WebMock.disable_net_connect!
+      WebMock.disable_net_connect! if defined?(WebMock)
     end
     super
   end

--- a/lib/webhookdb/tasks.rb
+++ b/lib/webhookdb/tasks.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "webhookdb"
+
+module Webhookdb::Tasks
+  # Load all Webhookdb Rake tasks.
+  # You can also load them individually.
+  def self.load_all
+    require "webhookdb/tasks/admin"
+    Webhookdb::Tasks::Admin.new
+    require "webhookdb/tasks/annotate"
+    Webhookdb::Tasks::Annotate.new
+    require "webhookdb/tasks/db"
+    Webhookdb::Tasks::DB.new
+    require "webhookdb/tasks/docs"
+    Webhookdb::Tasks::Docs.new
+    require "webhookdb/tasks/fixture"
+    Webhookdb::Tasks::Fixture.new
+    require "webhookdb/tasks/release"
+    Webhookdb::Tasks::Release.new
+    require "webhookdb/tasks/message"
+    Webhookdb::Tasks::Message.new
+    require "webhookdb/tasks/regress"
+    Webhookdb::Tasks::Regress.new
+    require "webhookdb/tasks/sidekiq"
+    Webhookdb::Tasks::Sidekiq.new
+    require "webhookdb/tasks/specs"
+    Webhookdb::Tasks::Specs.new
+  end
+end

--- a/lib/webhookdb/tasks/specs.rb
+++ b/lib/webhookdb/tasks/specs.rb
@@ -36,7 +36,7 @@ module Webhookdb::Tasks
           require "webhookdb/heroku"
           Webhookdb::Heroku.client.dyno.create(
             Webhookdb::Heroku.app_name,
-            command: "bundle exec rake specs:integration_step3",
+            command: "bundle exec rake specs:heroku_integration_step3",
             env: {"INTEGRATION_TESTS" => "true"},
             attach: false,
             time_to_live: 10.minute.to_i,

--- a/lib/webhookdb/version.rb
+++ b/lib/webhookdb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Webhookdb
-  VERSION = "0.1.1"
+  VERSION = "1.0.0"
 end

--- a/webhookdb.gemspec
+++ b/webhookdb.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_dependency("barnes", "~> 0.0")
   s.add_dependency("bcrypt", "~> 3.1")
   s.add_dependency("biz", "~> 1.8")
+  s.add_dependency("clipboard", "~> 1.3")
   s.add_dependency("concurrent-ruby", "~> 1.2")
   s.add_dependency("down", "~> 5.4")
   s.add_dependency("foreman", "~> 0.87")

--- a/webhookdb.gemspec
+++ b/webhookdb.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"]
   s.files += Dir["data/**/*"]
   s.files += Dir["db/**/*.rb"]
+  s.files += Dir["integration/**/*.rb"]
 
   s.add_dependency("activesupport", "~> 7.1")
   s.add_dependency("appydays", ">= 0.8")


### PR DESCRIPTION
Version to 1.0, update changelog

---

Fix busted integration step task step

---

Exclude theranest replicators from documentation

Can be done going forward with documentable: false
on the descriptor, but this is fine for the time being.

---

Improve healthcheck

- Get rid of the DB check. We don't need it, since we can have
  resilient webhook acceptance. We could check all our databases,
  but that seems like overkill for a healthcheck.
- Require webhookdb/version, status endpoint was broken.

---

Integration tests can be used in other gems

- Add the tests to the gem
- Do not require webmock to exist
- Do not require any custom matchers

---

Pryrc and Rakefile move to reusuable module

These are often needed by extension and deploy repos
so should be callable.