### PR TITLE
Integration tests can run from a gem

### DIFF
--- a/lib/webhookdb/tasks/specs.rb
+++ b/lib/webhookdb/tasks/specs.rb
@@ -10,13 +10,15 @@ module Webhookdb::Tasks
     def initialize
       super()
       namespace :specs do
-        desc "Run API integration tests"
+        desc "Run API integration tests in the 'integration' folder of this gem. " \
+             "To run your own tests, create a task similar to this one, " \
+             "that calls Webhookdb::SpecHelpers::Citest.run_tests."
         task :integration do
           require "rspec/core"
           require "slack-notifier"
           require "webhookdb/spec_helpers/integration"
           require "webhookdb/spec_helpers/citest"
-          Webhookdb::SpecHelpers::Citest.run_tests("integration")
+          Webhookdb::SpecHelpers::Citest.run_tests(Webhookdb::SpecHelpers::Citest::INTEGRATION_TESTS_DIR)
         end
 
         desc "The release process needs to finish quickly, so start the integration tests in another dyno."


### PR DESCRIPTION
The 'integration' folder was hard-coded so running the tests from another repo didn't work.

Make the integration test task use the gem's tests by default, but make it easier for callers to provide their own folder or folders (they can provide the default tasks,
in addition to their own).

