### PR TITLE
Add `front_signalwire_channel_app_v1` replicator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ PATH
       grape_logging (~> 1.8.4)
       httparty (~> 0.21)
       ice_cube
+      jwt (~> 2.7)
       liquid (~> 5.4)
       mail (~> 2.8)
       mimemagic (~> 0.4)
@@ -187,6 +188,7 @@ GEM
     inflecto (0.0.2)
     jmespath (1.6.2)
     json (2.7.1)
+    jwt (2.7.1)
     language_server-protocol (3.17.0.3)
     liquid (5.4.0)
     loggability (0.18.2)

--- a/db/migrations/038_webhookdb_api_key.rb
+++ b/db/migrations/038_webhookdb_api_key.rb
@@ -5,5 +5,9 @@ Sequel.migration do
     alter_table(:service_integrations) do
       add_column :webhookdb_api_key, :text, null: true
     end
+
+    alter_table(:idempotencies) do
+      add_column :stored_result, :jsonb, null: true
+    end
   end
 end

--- a/db/migrations/038_webhookdb_api_key.rb
+++ b/db/migrations/038_webhookdb_api_key.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:service_integrations) do
+      add_column :webhookdb_api_key, :text, null: true
+    end
+  end
+end

--- a/lib/webhookdb/api/service_integrations.rb
+++ b/lib/webhookdb/api/service_integrations.rb
@@ -199,6 +199,7 @@ If the list does not look correct, you can contact support at #{Webhookdb.suppor
               table: sint.table_name,
               url: sint.replicator.webhook_endpoint,
               webhook_secret: sint.webhook_secret,
+              webhookdb_api_key: sint.webhookdb_api_key,
             }
 
             field_name = params[:field]

--- a/lib/webhookdb/fixtures/service_integrations.rb
+++ b/lib/webhookdb/fixtures/service_integrations.rb
@@ -39,4 +39,8 @@ module Webhookdb::Fixtures::ServiceIntegrations
     self.backfill_key = "fake_bfkey"
     self.backfill_secret = "fake_bfsecret"
   end
+
+  decorator :with_api_key do
+    self.webhookdb_api_key ||= self.new_api_key
+  end
 end

--- a/lib/webhookdb/idempotency.rb
+++ b/lib/webhookdb/idempotency.rb
@@ -78,6 +78,11 @@ class Webhookdb::Idempotency < Webhookdb::Postgres::Model(:idempotencies)
     # Allows use of idempotency within an existing transaction block,
     # which is normally not allowed. Usually should be used with #stored,
     # since otherwise the result of the idempotency will be lost.
+    #
+    # NOTE: When calling code with using_seperate_connection,
+    # you may want to use the spec metadata `truncate: Webhookdb::Idempotency`
+    # since the row won't be covered by the spec's transaction.
+    #
     # @return [Builder]
     def using_seperate_connection
       self._sepconn = true

--- a/lib/webhookdb/oauth.rb
+++ b/lib/webhookdb/oauth.rb
@@ -76,5 +76,6 @@ end
 
 require "webhookdb/oauth/front_provider"
 Webhookdb::Oauth.register(Webhookdb::Oauth::FrontProvider)
+Webhookdb::Oauth.register(Webhookdb::Oauth::FrontSignalwireChannelProvider)
 require "webhookdb/oauth/intercom_provider"
 Webhookdb::Oauth.register(Webhookdb::Oauth::IntercomProvider)

--- a/lib/webhookdb/oauth/front_provider.rb
+++ b/lib/webhookdb/oauth/front_provider.rb
@@ -62,3 +62,10 @@ class Webhookdb::Oauth::FrontProvider < Webhookdb::Oauth::Provider
     root_sint.replicator.build_dependents
   end
 end
+
+class Webhookdb::Oauth::FrontSignalwireChannelProvider < Webhookdb::Oauth::FrontProvider
+  def key = "front_signalwire"
+  def app_name = "Front Signalwire Channel"
+  def client_id = Webhookdb::Front.signalwire_channel_client_id
+  def client_secret = Webhookdb::Front.signalwire_channel_client_secret
+end

--- a/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
+++ b/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
@@ -1,0 +1,339 @@
+# frozen_string_literal: true
+
+require "jwt"
+
+require "webhookdb/replicator/front_v1_mixin"
+
+# Front has a system of 'channels' but it is a challenge to use.
+# This replicator leverages WebhookDB (and our existing Front app)
+# to integrate Front and SignalWire messages,
+# using a sort of two-way sync that implements the necessary Front channel contrWcts.
+#
+# Note: In the future, we can abstract this to support other channels, with minimal changes.
+#
+# We have the following concepts to keep in mind:
+#
+# - The front_message_v1 replicator stores ALL messages in Front (inbound and outbound).
+# - The signalwire_message_v1 replicator stores ALL messages in SignalWire (inbound and outbound).
+# - For two-way sync, we care that Outbound Front messages are turned into Outbound SignalWire messages,
+#   and Inbound SignalWire messages are turned into Inbound Front messages.
+# - This means that, for the purpose of a two-way sync, this replicator can 'enqueue' deliveries by storing
+#   a row with *either* a Front message id (query Front for all outbound messages),
+#   *or* SignalWire message id (query signalwire for all inbound messages). When a row has *both* ids,
+#   it means it has been "delivered", so to speak.
+# - We can ignore inbound Front messages and outbound SignalWire messages
+#   (stored in their respective replicators), since those are created by this replicator.
+#
+# This means that, rather than having to manage state between two event-based systems,
+# we can *converge* to a correct state based on a given state.
+# This is much easier (possible?) to reason about and test,
+# and makes it possible to reuse code,
+#
+# The order of operations is:
+# - The channel description instructs the user to go to /v1/install/front_signalwire/setup.
+# - This loads a terminal, showing instructions for how to set up
+#   (enabling the WebhookDB Front app, setting up SignalWire).
+# - The state machine also asks for the phone number to use to send messages.
+#   - The phone number used to send messages is stored in the api_url.
+# - The state machine prints out the API token to use in Front.
+#   - The api token is stored in the 'webhookdb_api_key' field, which is searchable.
+# - The user is directed to Front, to install the WebhookDB SignalWire channel.
+# - The user inputs their API token and connects the channel.
+# - Front makes an 'authorization' request to /v1/install/front_signalwire/authorization.
+#   - This uses the API key to find the right front_signalwire_message_channel_app_v1 integration
+#     via the webhookdb_api_key field.
+#   - This stores the channel_id on the integration as the api_url.
+# - Front makes 'message' requests to /v1/install/front_signalwire/message/<opaque id>.
+#   - This upserts a DB row into the front_message_v1 replicator.
+#   - It also enqueues a backfill of this replicator.
+# - Front can make a 'delete' request to /v1/install/front_signalwire/message/<opaque id>.
+#   - This deletes deletes this service integration.
+# - Because this replicator is a dependent of signalwire_message_v1 (see explanation below),
+#   whenever a signalwire row is updated, this replicator will be triggered and enqueue a backfill.
+# - When this replicator backfills, it will:
+#   - Look for inbound SMS, and upsert a row into this replication table.
+#   - Look for outbound Front messages, and upsert a row into this replication table.
+#   - Find replication table rows without a signalwire id, and send an SMS.
+#   - Find replication table rows without a Front message id, and create a Front message
+#     using https://dev.frontapp.com/reference/sync-inbound-message
+#
+# Note: This replicator depends on signalwire_message_v1, NOT front_marketplace_root_v1,
+# because 1) an org will only have one Front marketplace root, logically,
+# given how it is installed, so it can be reliably inferred,
+# 2) we can create the marketplace root replicator based on this one,
+# and especially 3) Front will ALWAYS hit this replicator webhook for messages;
+# SiWnWlWire may not, though, it depends on how the numebr is configured.
+# By being a dependency of signalwire_message_v1, the replicator is called whenever
+# a SignalWire row changes.
+#
+class Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1 < Webhookdb::Replicator::Base
+  include Webhookdb::DBAdapter::ColumnTypes
+
+  def self.descriptor
+    return Webhookdb::Replicator::Descriptor.new(
+      name: "front_signalwire_message_channel_app_v1",
+      ctor: self,
+      feature_roles: [],
+      resource_name_singular: "Front/SignalWire Message",
+      dependency_descriptor: Webhookdb::Replicator::SignalwireMessageV1.descriptor,
+      supports_webhooks: true,
+      supports_backfill: true,
+      api_docs_url: "https://dev.frontapp.com/docs/getting-started-with-partner-channels",
+    )
+  end
+
+  def _remote_key_column
+    return Webhookdb::Replicator::Column.new(:external_id, TEXT)
+  end
+
+  def _denormalized_columns
+    return [
+      Webhookdb::Replicator::Column.new(:signalwire_sid, TEXT, optional: true, index: true),
+      Webhookdb::Replicator::Column.new(:front_message_id, TEXT, optional: true, index: true),
+      Webhookdb::Replicator::Column.new(:external_conversation_id, TEXT, optional: true, index: true),
+      Webhookdb::Replicator::Column.new(:row_updated_at, TIMESTAMP, defaulter: :now, optional: true, index: true),
+      Webhookdb::Replicator::Column.new(:direction, TEXT),
+      Webhookdb::Replicator::Column.new(:body, TEXT),
+      Webhookdb::Replicator::Column.new(:sender, TEXT),
+      Webhookdb::Replicator::Column.new(:recipient, TEXT),
+    ]
+  end
+
+  def _timestamp_column_name
+    return :row_updated_at
+  end
+
+  def _update_where_expr
+    return (self.qualified_table_sequel_identifier[:signalwire_sid] =~ nil) |
+        (self.qualified_table_sequel_identifier[:front_message_id] =~ nil)
+  end
+
+  def format_phone(s) = Webhookdb::PhoneNumber.format_e164(s)
+  def support_phone = self.format_phone(self.service_integration.api_url)
+
+  def calculate_webhook_state_machine
+    if (step = self.calculate_dependency_state_machine_step(dependency_help: ""))
+      return step
+    end
+    step = Webhookdb::Replicator::StateMachineStep.new
+    marketplace_root = self.service_integration.
+      organization.
+      service_integrations.
+      find { |si| si.service_name == "front_marketplace_root_v1" }
+    if marketplace_root.nil?
+      step.output = %(To set up Front Channels with WebhookDB,
+you must install the WebhookDB app from the Front App Store.
+Head over to https://front.com/integrations/webhookdb to set things up,
+and then try again.)
+      return step.completed
+    end
+    if self.service_integration.api_url.blank?
+      step.output = %(This Front Channel will be linked to a specific number in SignalWire.
+Choose the phone number to connect to Front.)
+      return step.prompting("Phone number").api_url(self.service_integration)
+    end
+    self.service_integration.webhookdb_api_key ||= self.service_integration.new_api_key
+    self.service_integration.save_changes
+    step.output = %(Almost there! You can now finish installing the WebhookDB - SignalWire Channel in Front.
+
+1. In Front, go to Settings -> Company -> Channels (in the left nav), Connect a Channel,
+   and choose the 'WebhookDB - SignalWire' channel.
+2. In the 'Token' field, enter this API Key: #{self.service_integration.webhookdb_api_key}
+
+If you need to find this key, you can run `webhookdb integrations info front_signalwire_message_channel_app_v1`.
+
+All of this information can be found in the WebhookDB docs, at https://docs.webhookdb.com/guides/front-channel-signalwire/)
+    return step.completed
+  end
+
+  def calculate_backfill_state_machine
+    # The backfills here are not normal backfills, requested by the customer.
+    # They are procedurally enqueued when we upsert data.
+    # So just reuse the webhook state machine.
+    return self.calculate_webhook_state_machine
+  end
+
+  def process_webhooks_synchronously? = true
+
+  def synchronous_processing_response_body(upserted:, request:)
+    case request.body["type"]
+      when "authorization"
+        self.front_channel_id = request.body.fetch("payload").fetch("channel_id")
+        self.service_integration.save_changes
+        return {type: "success", webhook_url: "#{Webhookdb.api_url}/v1/install/front_signalwire/channel"}.to_json
+      when "delete"
+        self.service_integration.destroy
+        return "{}"
+      when "message", "message_autoreply"
+        return {
+          type: "success",
+          external_id: upserted.fetch(:external_id),
+          external_conversation_id: upserted.fetch(:external_conversation_id),
+        }.to_json
+      else
+        return "{}"
+    end
+  end
+
+  def front_channel_id = self.service_integration.backfill_key
+
+  def front_channel_id=(c)
+    self.service_integration.backfill_key = c
+  end
+
+  def _webhook_response(request)
+    return Webhookdb::Front.webhook_response(request, Webhookdb::Front.signalwire_channel_app_secret)
+  end
+
+  def _resource_and_event(request)
+    type = request.body["type"]
+    is_signalwire = type.nil?
+    return request.body, nil if is_signalwire
+
+    # This ends up being called for 'authorization' and 'delete' messages too.
+    # Those are handled in the webhook response body.
+    is_message_type = ["message", "message_autoreply"].include?(type)
+    return nil, nil unless is_message_type
+
+    resource = request.body.dup
+    payload = resource.fetch("payload")
+    mid = if type == "message"
+            payload.fetch("id")
+      else
+        replied_to_id = payload["_links"]["related"]["message_replied_to"].split("/").last
+        "#{replied_to_id}_autoreply"
+    end
+    resource["front_message_id"] = mid
+    # Use the Front ID to identify this outbound message.
+    resource["external_id"] = mid
+    resource["direction"] = "outbound"
+    resource["body"] = payload.fetch("text")
+    resource["sender"] = self.support_phone
+    resource["recipient"] = self._front_recipient_phone(payload)
+    # All messages get the same conversation with SMS/chat, unlike email.
+    resource["external_conversation_id"] = resource["recipient"]
+    return resource, nil
+  end
+
+  def _front_recipient_phone(payload)
+    recipient = payload["recipients"].find { |r| r.fetch("role") == "to" }
+    raise Webhookdb::InvariantViolation, "no recipient found in #{payload}" if recipient.nil?
+    return self.format_phone(recipient.fetch("handle"))
+  end
+
+  def on_dependency_webhook_upsert(_replicator, payload, changed:)
+    return unless changed
+    return unless payload.fetch(:direction) == "inbound"
+    return unless payload.fetch(:to) == self.support_phone
+    body = JSON.parse(payload.fetch(:data))
+    body.merge!(
+      "external_id" => payload.fetch(:signalwire_id),
+      "signalwire_sid" => payload.fetch(:signalwire_id),
+      "direction" => "inbound",
+      "sender" => payload.fetch(:from),
+      "recipient" => self.support_phone,
+      "external_conversation_id" => payload.fetch(:from),
+    )
+    self.upsert_webhook_body(body)
+  end
+
+  def _notify_dependents(inserting, changed)
+    super
+    return unless changed
+    Webhookdb::BackfillJob.create_recursive(service_integration: self.service_integration, incremental: true).enqueue
+  end
+
+  def _backfillers = [Backfiller.new(self)]
+
+  class Backfiller < Webhookdb::Backfiller
+    def initialize(replicator)
+      super()
+      @replicator = replicator
+      @signalwire_sint = replicator.service_integration.depends_on
+    end
+
+    def handle_item(item)
+      front_id = item.fetch(:front_message_id)
+      sw_id = item.fetch(:signalwire_sid)
+      if (front_id && sw_id) || (!front_id && !sw_id)
+        msg = "row should have a front id OR signalwire id, should not have been inserted, or selected: #{item}"
+        raise Webhookdb::InvariantViolation, msg
+      end
+      sender = @replicator.format_phone(item.fetch(:sender))
+      recipient = @replicator.format_phone(item.fetch(:recipient))
+      body = item.fetch(:body)
+      idempotency_key = "fsmca-fims-#{item.fetch(:external_id)}"
+      idempotency = Webhookdb::Idempotency.once_ever.stored.using_seperate_connection.under_key(idempotency_key)
+      if front_id.nil?
+        texted_at = Time.parse(item.fetch(:data).fetch("date_created"))
+        if texted_at < Webhookdb::Front.channel_sync_refreshness_cutoff.seconds.ago
+          # Do not sync old rows, just mark them synced
+          item[:front_message_id] = "skipped_due_to_age"
+        else
+          # sync the message into Front
+          front_response_body = idempotency.execute do
+            self._sync_front_inbound(sender:, texted_at:, item:, body:)
+          end
+          item[:front_message_id] = front_response_body.fetch("message_uid")
+        end
+      else
+        messaged_at = Time.at(item.fetch(:data).fetch("created_at"))
+        if messaged_at < Webhookdb::Front.channel_sync_refreshness_cutoff.seconds.ago
+          # Do not sync old rows, just mark them synced
+          item[:signalwire_sid] = "skipped_due_to_age"
+        else
+          # send the SMS via signalwire
+          signalwire_resp = idempotency.execute do
+            Webhookdb::Signalwire.send_sms(
+              from: sender,
+              to: recipient,
+              body:,
+              space_url: @signalwire_sint.api_url,
+              project_id: @signalwire_sint.backfill_key,
+              api_key: @signalwire_sint.backfill_secret,
+              logger: @replicator.logger,
+            )
+          end
+          item[:signalwire_sid] = signalwire_resp.fetch("sid")
+        end
+      end
+      @replicator.upsert_webhook_body(item.deep_stringify_keys)
+    end
+
+    def _sync_front_inbound(sender:, texted_at:, item:, body:)
+      body = {
+        sender: {handle: sender},
+        body:,
+        delivered_at: texted_at.to_i,
+        metadata: {
+          external_id: item.fetch(:external_id),
+          external_conversation_id: item.fetch(:external_conversation_id),
+        },
+      }
+      token = JWT.encode(
+        {
+          iss: Webhookdb::Front.signalwire_channel_app_id,
+          jti: Webhookdb::Front.channel_jwt_jti,
+          sub: @replicator.front_channel_id,
+          exp: 10.seconds.from_now.to_i,
+        },
+        Webhookdb::Front.signalwire_channel_app_secret,
+      )
+      resp = Webhookdb::Http.post(
+        "https://api2.frontapp.com/channels/#{@replicator.front_channel_id}/inbound_messages",
+        body,
+        headers: {"Authorization" => "Bearer #{token}"},
+        timeout: Webhookdb::Front.http_timeout,
+        logger: @replicator.logger,
+      )
+      resp.parsed_response
+    end
+
+    def fetch_backfill_page(*)
+      rows = @replicator.admin_dataset do |ds|
+        ds.where(Sequel[signalwire_sid: nil] | Sequel[front_message_id: nil]).all
+      end
+      return rows, nil
+    end
+  end
+end

--- a/lib/webhookdb/replicator/front_v1_mixin.rb
+++ b/lib/webhookdb/replicator/front_v1_mixin.rb
@@ -13,7 +13,7 @@ module Webhookdb::Replicator::FrontV1Mixin
   end
 
   def _webhook_response(request)
-    return Webhookdb::Front.webhook_response(request)
+    return Webhookdb::Front.webhook_response(request, Webhookdb::Front.app_secret)
   end
 
   def on_dependency_webhook_upsert(_replicator, _payload, *)

--- a/lib/webhookdb/signalwire.rb
+++ b/lib/webhookdb/signalwire.rb
@@ -16,7 +16,7 @@ module Webhookdb::Signalwire
     sms_allowed = self.sms_allowlist.any? { |pattern| File.fnmatch(pattern, to) }
     unless sms_allowed
       self.logger.warn("signalwire_sms_not_allowed", to:)
-      return {"message_uid" => "skipped"}
+      return {"sid" => "skipped"}
     end
     return self.http_request(
       :post,

--- a/lib/webhookdb/spec_helpers/postgres.rb
+++ b/lib/webhookdb/spec_helpers/postgres.rb
@@ -31,6 +31,7 @@ module Webhookdb::SpecHelpers::Postgres
     context.around(:each) do |example|
       Webhookdb::Postgres.unsafe_skip_transaction_check = true if example.metadata[:no_transaction_check]
 
+      _truncate(example)
       setting = example.metadata[:db]
       if setting && setting != :no_transaction
         Webhookdb::SpecHelpers::Postgres.wrap_example_in_transactions(example)
@@ -44,9 +45,17 @@ module Webhookdb::SpecHelpers::Postgres
       Webhookdb::Postgres.unsafe_skip_transaction_check = false if example.metadata[:no_transaction_check]
 
       truncate_all if example.metadata[:db] == :no_transaction
+      _truncate(example)
     end
 
     super
+  end
+
+  module_function def _truncate(example)
+    tr = example.metadata[:truncate]
+    return unless tr
+    tr = [tr] unless tr.respond_to?(:to_ary)
+    tr.each(&:truncate)
   end
 
   ### Run the specified +example+ in the context of a transaction for each loaded

--- a/lib/webhookdb/spec_helpers/service.rb
+++ b/lib/webhookdb/spec_helpers/service.rb
@@ -423,6 +423,11 @@ module Webhookdb::SpecHelpers::Service
       super
     end
 
+    def delete(uri, params={}, env={}, &)
+      env, params = make_json_request(env, params)
+      super
+    end
+
     def make_json_request(env, params)
       env["CONTENT_TYPE"] ||= "application/json"
       params = Webhookdb::Json.encode(params) if env["CONTENT_TYPE"] == "application/json" && !params.is_a?(String)

--- a/spec/webhookdb/api/service_integrations_spec.rb
+++ b/spec/webhookdb/api/service_integrations_spec.rb
@@ -434,7 +434,7 @@ RSpec.describe Webhookdb::API::ServiceIntegrations,
         include(
           inserted_at: match_time(Time.now).within(5),
           organization_id: sint.organization_id,
-          request_body: "",
+          request_body: "{}",
           request_headers: hash_including("Host" => "example.org"),
           request_path: "/v1/service_integrations/xyz/v2/listings",
           request_method: "DELETE",

--- a/spec/webhookdb/front_spec.rb
+++ b/spec/webhookdb/front_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe Webhookdb::Front do
 
   def valid_req
     base_string = "#{front_timestamp_header}:#{body}"
-    valid_auth_header = OpenSSL::HMAC.base64digest(OpenSSL::Digest.new("sha256"), Webhookdb::Front.api_secret,
-                                                   base_string,)
+    valid_auth_header = OpenSSL::HMAC.base64digest(
+      OpenSSL::Digest.new("sha256"), Webhookdb::Front.app_secret, base_string,
+    )
     req = fake_request(input: body)
     req.add_header("HTTP_X_FRONT_REQUEST_TIMESTAMP", front_timestamp_header)
     req.add_header("HTTP_X_FRONT_SIGNATURE", valid_auth_header)
@@ -25,35 +26,35 @@ RSpec.describe Webhookdb::Front do
 
   describe "verify_signature" do
     it "returns false for invalid auth headers" do
-      expect(described_class.verify_signature(invalid_req)).to be(false)
+      expect(described_class.verify_signature(invalid_req, described_class.app_secret)).to be(false)
     end
 
     it "returns true for valid auth headers" do
-      expect(described_class.verify_signature(valid_req)).to be(true)
+      expect(described_class.verify_signature(valid_req, described_class.app_secret)).to be(true)
     end
   end
 
   describe "webhook_response" do
     it "returns a 401 if there is no signature header" do
       req = fake_request(input: body)
-      resp = described_class.webhook_response(req)
+      resp = described_class.webhook_response(req, described_class.app_secret)
       expect(resp).to have_attributes(status: 401, reason: "missing signature")
     end
 
     it "returns a 401 for an invalid signature header" do
-      resp = described_class.webhook_response(invalid_req)
+      resp = described_class.webhook_response(invalid_req, described_class.app_secret)
       expect(resp).to have_attributes(status: 401, reason: "invalid signature")
     end
 
     it "returns a 200 with a valid signature header" do
-      resp = described_class.webhook_response(valid_req)
+      resp = described_class.webhook_response(valid_req, described_class.app_secret)
       expect(resp).to have_attributes(status: 200)
     end
   end
 
   describe "initial_verification_request_response" do
     it "returns error when credentials are invalid" do
-      resp = described_class.initial_verification_request_response(invalid_req)
+      resp = described_class.initial_verification_request_response(invalid_req, described_class.app_secret)
       expect(resp).to have_attributes(status: 401, reason: "invalid credentials")
     end
 
@@ -61,7 +62,7 @@ RSpec.describe Webhookdb::Front do
       req = valid_req
       req.add_header("HTTP_X_FRONT_CHALLENGE", "challenge_string")
 
-      resp = described_class.initial_verification_request_response(req)
+      resp = described_class.initial_verification_request_response(req, described_class.app_secret)
       expect(resp).to have_attributes(
         status: 200,
         body: {challenge: "challenge_string"}.to_json,

--- a/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
+++ b/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
@@ -1,0 +1,526 @@
+# frozen_string_literal: true
+
+require "support/shared_examples_for_replicators"
+
+RSpec.describe Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1, :db do
+  service_name = "front_signalwire_message_channel_app_v1"
+  let(:org) { Webhookdb::Fixtures.organization.create }
+  let(:fac) { Webhookdb::Fixtures.service_integration(organization: org) }
+  let(:signalwire_sint) { fac.create(service_name: "signalwire_message_v1") }
+  let(:frontapp_sint) { fac.create(service_name: "front_marketplace_root_v1") }
+  let(:sint) { fac.depending_on(signalwire_sint).create(service_name:) }
+  let(:svc) { sint.replicator }
+
+  it_behaves_like "a replicator", service_name do
+    let(:sint) { super().update(api_url: "2223334444") }
+    let(:supports_row_diff) { false }
+    let(:body) do
+      {
+        "type" => "message_autoreply",
+        "payload" => {
+          "_links" => {
+            "related" => {
+              "conversation" => "https://api2.frontapp.com/conversations/cnv_55c8c149",
+              "message_replied_to" => "https://api2.frontapp.com/messages/msg_1ab23cd4",
+            },
+          },
+          "type" => "auto_reply",
+          "is_inbound" => false,
+          "created_at" => 1_453_770_984.123,
+          "body" => "I'll get back to you as soon as possible.",
+          "text" => "I'll get back to you as soon as possible.",
+          "recipients" => [{"_links" => {"related" => {"contact" => "https://api2.frontapp.com/contacts/crd_55c8c149"}},
+                            "handle" => "9998887777", "role" => "to",}],
+          "attachments" => [],
+        },
+        "front_message_id" => "msg_1ab23cd4_autoreply",
+        "external_id" => "msg_1ab23cd4_autoreply",
+        "direction" => "outbound",
+        "body" => "I'll get back to you as soon as possible.",
+        "sender" => "https://fake-url.com",
+        "recipient" => "9998887777",
+        "external_conversation_id" => "9998887777",
+      }
+    end
+    let(:expected_row) do
+      include(
+        sender: "+12223334444",
+        recipient: "+19998887777",
+        body: "I'll get back to you as soon as possible.",
+        direction: "outbound",
+        external_conversation_id: "+19998887777",
+        external_id: "msg_1ab23cd4_autoreply",
+        front_message_id: "msg_1ab23cd4_autoreply",
+      )
+    end
+  end
+
+  it_behaves_like "a replicator dependent on another", service_name, "signalwire_message_v1" do
+    let(:no_dependencies_message) { "This integration requires SignalWire Messages to sync" }
+  end
+
+  describe "upsert_webhook" do
+    before(:each) do
+      sint.update(api_url: "+2223334444")
+      sint.organization.prepare_database_connections
+      svc.create_table
+    end
+
+    after(:each) do
+      sint.organization.remove_related_database
+    end
+
+    it "does not overwrite if signalwire and front ids are set" do
+      body = {
+        "external_id" => "some_id",
+        "signalwire_sid" => "sw_id",
+        "direction" => "inbound",
+        "body" => "initial insert",
+        "sender" => "+2223334444",
+        "recipient" => "+5556667777",
+        "external_conversation_id" => "convo",
+      }
+
+      # Initial upsert adds the row
+      svc.upsert_webhook_body(body)
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(
+          signalwire_sid: "sw_id",
+          front_message_id: nil,
+          body: "initial insert",
+        ),
+      )
+
+      # Update can modify the row
+      body["body"] = "secondinsert"
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(
+          signalwire_sid: "sw_id",
+          front_message_id: nil,
+          body: "initial insert",
+        ),
+      )
+
+      # Replacing the ID should work (though we'd never do this in reality)
+      body.delete("signalwire_sid")
+      body["front_message_id"] = "frontid"
+      body["body"] = "front msg"
+      svc.upsert_webhook_body(body)
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(
+          signalwire_sid: nil,
+          front_message_id: "frontid",
+          body: "front msg",
+        ),
+      )
+
+      # Setting both IDs works
+      body["signalwire_sid"] = "sw_id"
+      body["front_message_id"] = "front_id"
+      body["body"] = "combined"
+      svc.upsert_webhook_body(body)
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(
+          signalwire_sid: "sw_id",
+          front_message_id: "front_id",
+          body: "combined",
+        ),
+      )
+
+      # Once both IDs are set, we cannot modify the row
+      body["body"] = "updated body"
+      svc.upsert_webhook_body(body)
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(
+          signalwire_sid: "sw_id",
+          front_message_id: "front_id",
+          body: "combined",
+        ),
+      )
+    end
+
+    it "enques a backfill when any rows change" do
+      body = {
+        "external_id" => "some_id",
+        # Needs both ids, so the second upsert does not change.
+        "front_message_id" => "front_id",
+        "signalwire_sid" => "sw_id",
+        "direction" => "inbound",
+        "body" => "initial insert",
+        "sender" => "+2223334444",
+        "recipient" => "+5556667777",
+        "external_conversation_id" => "convo",
+      }
+      svc.upsert_webhook_body(body)
+      expect(Webhookdb::BackfillJob.all).to have_length(1)
+      svc.upsert_webhook_body(body)
+      expect(Webhookdb::BackfillJob.all).to have_length(1)
+    end
+
+    it "upserts a front message" do
+      payload = {
+        _links: {
+          self: "https://api2.frontapp.com/messages/msg_55c8c149",
+          related: {
+            conversation: "https://api2.frontapp.com/conversations/cnv_55c8c149",
+            message_replied_to: "https://api2.frontapp.com/messages/msg_1ab23cd4",
+          },
+        },
+        id: "msg_55c8c149",
+        type: "email",
+        is_inbound: true,
+        draft_mode: nil,
+        created_at: 1_453_770_984.123,
+        blurb: "Anything less than immortality is a...",
+        author: {},
+        recipients: [
+          {
+            _links: {
+              related: {
+                contact: "https://api2.frontapp.com/contacts/crd_55c8c149",
+              },
+            },
+            handle: "9998887777",
+            role: "to",
+          },
+        ],
+        body: "Anything less than immortality is a complete waste of time.",
+        text: "Anything less than immortality is a complete waste of time.",
+        attachments: [],
+        metadata: {},
+      }
+      svc.upsert_webhook_body({type: "message", payload:}.as_json)
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(
+          external_id: "msg_55c8c149",
+          signalwire_sid: nil,
+          front_message_id: "msg_55c8c149",
+          external_conversation_id: "+19998887777",
+          direction: "outbound",
+          body: "Anything less than immortality is a complete waste of time.",
+          sender: "+12223334444",
+          recipient: "+19998887777",
+        ),
+      )
+    end
+
+    it "upserts a front autoreply" do
+      payload = {
+        _links: {
+          related: {
+            conversation: "https://api2.frontapp.com/conversations/cnv_55c8c149",
+            message_replied_to: "https://api2.frontapp.com/messages/msg_1ab23cd4",
+          },
+        },
+        type: "auto_reply",
+        is_inbound: false,
+        created_at: 1_453_770_984.123,
+        body: "I'll get back to you as soon as possible.",
+        text: "I'll get back to you as soon as possible.",
+        recipients: [
+          {
+            _links: {
+              related: {
+                contact: "https://api2.frontapp.com/contacts/crd_55c8c149",
+              },
+            },
+            handle: "9998887777",
+            role: "to",
+          },
+        ],
+        attachments: [],
+      }
+      svc.upsert_webhook_body({type: "message_autoreply", payload:}.as_json)
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(
+          external_id: "msg_1ab23cd4_autoreply",
+          signalwire_sid: nil,
+          front_message_id: "msg_1ab23cd4_autoreply",
+          external_conversation_id: "+19998887777",
+          direction: "outbound",
+          body: "I'll get back to you as soon as possible.",
+          sender: "+12223334444",
+          recipient: "+19998887777",
+        ),
+      )
+    end
+  end
+
+  describe "synchronous_processing_response_body" do
+    def doit(body, upserted={})
+      return svc.synchronous_processing_response_body(
+        upserted:,
+        request: Webhookdb::Replicator::WebhookRequest.new(body: body.as_json),
+      )
+    end
+
+    it "stores the channel_id on authorization" do
+      got = doit({type: "authorization", payload: {channel_id: "ch_abc"}})
+      expect(sint.refresh).to have_attributes(backfill_key: "ch_abc")
+      expect(got).to eq('{"type":"success","webhook_url":"http://localhost:18001/v1/install/front_signalwire/channel"}')
+    end
+
+    it "destroys the service integration on delete" do
+      got = doit({type: "delete", payload: {channel_id: "ch_abc"}})
+      expect(got).to eq("{}")
+      expect(Webhookdb::ServiceIntegration.where(id: sint.id).all).to be_empty
+    end
+
+    it "errors for other types" do
+      got = doit({type: "something else"})
+      expect(got).to eq("{}")
+    end
+
+    it "returns the external and convo ids for message and autoreply types" do
+      got = doit({type: "message"}, {external_id: "eid", external_conversation_id: "convoid"})
+      expect(got).to eq('{"type":"success","external_id":"eid","external_conversation_id":"convoid"}')
+    end
+  end
+
+  describe "on_dependency_webhook_upsert" do
+    let(:customer_phone) { "+15017122661" }
+    let(:support_phone) { "+15558675310" }
+    let(:data) { JSON.parse(<<~J) }
+      {
+        "account_sid": "AC123",
+        "api_version": "2010-04-01",
+        "body": "body",
+        "date_created": "Thu, 30 Jul 2015 20:12:31 +0000",
+        "date_sent": "Thu, 30 Jul 2015 20:12:33 +0000",
+        "date_updated": "Thu, 30 Jul 2015 20:12:33 +0000",
+        "direction": "inbound",
+        "error_code": null,
+        "error_message": null,
+        "from": "#{customer_phone}",
+        "messaging_service_sid": "MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "num_media": "0",
+        "num_segments": "1",
+        "price": null,
+        "price_unit": null,
+        "sid": "SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "status": "sent",
+        "subresource_uris": {
+          "media": "/2010-04-01/Accounts/AC123/Messages/SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Media.json"
+        },
+        "to": "#{support_phone}",
+        "uri": "/2010-04-01/Accounts/AC123/Messages/SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.json"
+      }
+    J
+    let(:row) { signalwire_sint.replicator.upsert_webhook_body(data, upsert: false) }
+
+    before(:each) do
+      sint.update(api_url: support_phone)
+    end
+
+    it "noops if the signalwire row has not changed" do
+      expect do
+        svc.on_dependency_webhook_upsert(signalwire_sint.replicator, row, changed: false)
+      end.to_not raise_error
+    end
+
+    it "noops for outbound messages" do
+      row[:direction] = "outbound-api"
+      expect do
+        svc.on_dependency_webhook_upsert(signalwire_sint.replicator, row, changed: true)
+      end.to_not raise_error
+    end
+
+    it "upserts a row for inbound messages, and enqueues a backfill" do
+      sint.organization.prepare_database_connections
+      svc.create_table
+      svc.on_dependency_webhook_upsert(signalwire_sint.replicator, row, changed: true)
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(
+          external_id: "SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+          signalwire_sid: "SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+          front_message_id: nil,
+          external_conversation_id: "+15017122661",
+          direction: "inbound",
+          body: "body",
+          sender: customer_phone,
+          recipient: support_phone,
+        ),
+      )
+    ensure
+      sint.organization.remove_related_database
+    end
+
+    it "noops inbound messages from an unconfigured number" do
+      row[:to] = "+15552223333"
+      expect do
+        svc.on_dependency_webhook_upsert(signalwire_sint.replicator, row, changed: true)
+      end.to_not raise_error
+    end
+  end
+
+  describe "state machine calculation" do
+    describe "calculate_webhook_state_machine" do
+      before(:each) do
+        _ = frontapp_sint
+      end
+
+      it "requires for the signalwire dependency" do
+        sint.update(depends_on: nil)
+        signalwire_sint.destroy
+        sm = sint.replicator.calculate_webhook_state_machine
+        expect(sm).to have_attributes(
+          output: include("This integration requires SignalWire Messages to sync"),
+          complete: true,
+        )
+      end
+
+      it "requires the front marketplace dependency" do
+        frontapp_sint.destroy
+        sm = sint.replicator.calculate_webhook_state_machine
+        expect(sm).to have_attributes(
+          output: include("you must install the WebhookDB app"),
+          complete: true,
+        )
+      end
+
+      it "prompts for the signalwire phone number" do
+        sint.update(api_url: "")
+        sm = sint.replicator.calculate_webhook_state_machine
+        expect(sm).to have_attributes(
+          output: include("This Front Channel will be linked to a specific number in SignalWire"), needs_input: true,
+          prompt: be_present,
+          prompt_is_secret: false,
+          post_to_url: end_with("/transition/api_url"),
+          complete: false,
+        )
+      end
+
+      it "succeeds and prints a success response if fields are set" do
+        sint.update(api_url: "2223334444")
+        sm = sint.replicator.calculate_webhook_state_machine
+        expect(sm).to have_attributes(
+          output: include("Almost there! You can now finish installing the"),
+          needs_input: false,
+          complete: true,
+        )
+        expect(sint.refresh).to have_attributes(webhookdb_api_key: start_with("sk/svi_"))
+      end
+    end
+
+    describe "calculate_backfill_state_machine" do
+      it "is the same as the webhook state machine" do
+        sm = sint.replicator.calculate_backfill_state_machine
+        expect(sm).to have_attributes(
+          output: include("To set up Front Channels with WebhookDB"),
+        )
+      end
+    end
+  end
+
+  describe "backfill", truncate: Webhookdb::Idempotency do
+    support_phone = "2223334444"
+    customer_phone = "5556667777"
+    before(:each) do
+      signalwire_sint.update(backfill_key: "projid", backfill_secret: "apikey", api_url: "whdbtest")
+      sint.replicator.front_channel_id = "fchan1"
+      sint.update(api_url: support_phone)
+      sint.organization.prepare_database_connections
+      svc.create_table
+    end
+
+    after(:each) do
+      sint.organization.remove_related_database
+    end
+
+    it "sends a Signalwire SMS for rows without a Signalwire id",
+       :no_transaction_check,
+       reset_configuration: Webhookdb::Signalwire do
+      Webhookdb::Signalwire.sms_allowlist = ["*"]
+      svc.admin_dataset do |ds|
+        ds.insert(
+          external_id: "front_id_only",
+          front_message_id: "fmid1",
+          sender: support_phone,
+          recipient: customer_phone,
+          body: "hi",
+          data: {created_at: Time.parse("2023-01-10T12:00:00Z").to_i}.to_json,
+        )
+        ds.insert(
+          external_id: "OLD_front_id_only",
+          front_message_id: "OLD_fmid1",
+          sender: support_phone,
+          recipient: customer_phone,
+          body: "hi",
+          data: {created_at: Time.parse("2023-01-05T12:00:00Z").to_i}.to_json,
+        )
+        ds.insert(external_id: "both_id", front_message_id: "fmid2", signalwire_sid: "swid", data: "{}")
+      end
+      req = stub_request(:post, "https://whdbtest.signalwire.com/2010-04-01/Accounts/projid/Messages.json").
+        with(
+          body: {"Body" => "hi", "From" => "+12223334444", "To" => "+15556667777"},
+          headers: {
+            "Accept" => "application/json",
+            "Authorization" => "Basic cHJvamlkOmFwaWtleQ==",
+            "Content-Type" => "application/x-www-form-urlencoded",
+          },
+        ).to_return(json_response({sid: "SWID123"}))
+      # Freeze time for age
+      Timecop.freeze("2023-01-10T12:00:00Z") do
+        backfill(sint)
+      end
+      expect(req).to have_been_made
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(external_id: "front_id_only", front_message_id: "fmid1", signalwire_sid: "SWID123"),
+        include(external_id: "both_id", front_message_id: "fmid2", signalwire_sid: "swid"),
+        include(external_id: "OLD_front_id_only", front_message_id: "OLD_fmid1", signalwire_sid: "skipped_due_to_age"),
+      )
+    end
+
+    it "syncs a Front message for rows without a Front id", :no_transaction_check do
+      svc.admin_dataset do |ds|
+        ds.insert(external_id: "both_id", front_message_id: "fmid", signalwire_sid: "swid1", data: "{}")
+        ds.insert(
+          external_id: "sw_id_only",
+          signalwire_sid: "swid2",
+          external_conversation_id: "convoid",
+          sender: "12223334444",
+          recipient: "4445556666",
+          body: "hi WHDB",
+          data: {date_created: Time.parse("2023-01-10T11:00:00Z").rfc2822}.to_json,
+        )
+        ds.insert(
+          external_id: "OLD_sw_id_only",
+          signalwire_sid: "OLD_swid2",
+          external_conversation_id: "convoid",
+          sender: "12223334444",
+          recipient: "4445556666",
+          body: "hi WHDB",
+          data: {date_created: Time.parse("2023-01-05T11:00:00Z").rfc2822}.to_json,
+        )
+      end
+      expect(Webhookdb::Front).to receive(:channel_jwt_jti).and_return("abcd")
+      # rubocop:disable Layout/LineLength
+      req = stub_request(:post, "https://api2.frontapp.com/channels/fchan1/inbound_messages").
+        with(
+          body: {
+            sender: {handle: "+12223334444"},
+            body: "hi WHDB",
+            delivered_at: 1_673_348_400,
+            metadata: {external_id: "sw_id_only", external_conversation_id: "convoid"},
+          }.as_json,
+          headers: {
+            "Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJmcm9udF9zd2NoYW5fYXBwX2lkIiwianRpIjoiYWJjZCIsInN1YiI6ImZjaGFuMSIsImV4cCI6MTY3MzM1MjAxMH0._arrm-SXOiTPDz_43Iek_JlyfOD0KfTgYjJN27bIFxQ",
+            "Content-Type" => "application/json",
+          },
+        ).
+        to_return(json_response({message_uid: "FMID2"}, status: 202))
+      # rubocop:enable Layout/LineLength
+
+      # Freeze time for Front JWT expiry and age
+      Timecop.freeze("2023-01-10T12:00:00Z") do
+        backfill(sint)
+      end
+      expect(req).to have_been_made
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(external_id: "both_id", signalwire_sid: "swid1", front_message_id: "fmid"),
+        include(external_id: "sw_id_only", signalwire_sid: "swid2", front_message_id: "FMID2"),
+        include(external_id: "OLD_sw_id_only", signalwire_sid: "OLD_swid2", front_message_id: "skipped_due_to_age"),
+      )
+    end
+  end
+end

--- a/spec/webhookdb/service_integration_spec.rb
+++ b/spec/webhookdb/service_integration_spec.rb
@@ -219,6 +219,23 @@ RSpec.describe "Webhookdb::ServiceIntegration", :db do
     end
   end
 
+  describe "api key" do
+    it "generates a secure, unique key" do
+      sint = Webhookdb::Fixtures.service_integration.create(opaque_id: "oid")
+      k = sint.new_api_key
+      expect(k).to start_with("sk/oid/")
+      expect(k).to have_length(be > 40)
+    end
+
+    it "can look up a service integration based on its api key" do
+      sint1 = Webhookdb::Fixtures.service_integration.with_api_key.create
+      sint2 = Webhookdb::Fixtures.service_integration.with_api_key.create
+
+      expect(described_class.for_api_key(sint1.webhookdb_api_key)).to be === sint1
+      expect(described_class.for_api_key("not a real key")).to be_nil
+    end
+  end
+
   describe "::create_disambiguated" do
     it "uses the service name with a unique tag as table name if no table name is provided" do
       organization = Webhookdb::Fixtures.organization.create

--- a/spec/webhookdb/signalwire_spec.rb
+++ b/spec/webhookdb/signalwire_spec.rb
@@ -31,16 +31,15 @@ RSpec.describe Webhookdb::Signalwire do
     end
 
     it "skips sending if the to number is not allowlisted" do
-      expect do
-        described_class.send_sms(
-          from: "+12223334444",
-          to: "+14445556666",
-          body: "hello",
-          project_id: "proj",
-          api_key: "swkey",
-          logger: nil,
-        )
-      end.to_not raise_error
+      got = described_class.send_sms(
+        from: "+12223334444",
+        to: "+14445556666",
+        body: "hello",
+        project_id: "proj",
+        api_key: "swkey",
+        logger: nil,
+      )
+      expect(got).to eq({"sid" => "skipped"})
     end
   end
 end

--- a/webhookdb.gemspec
+++ b/webhookdb.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency("grape-swagger", "~> 2.0.0")
   s.add_dependency("httparty", "~> 0.21")
   s.add_dependency("ice_cube")
+  s.add_dependency("jwt", "~> 2.7")
   s.add_dependency("liquid", "~> 5.4")
   s.add_dependency("mail", "~> 2.8")
   s.add_dependency("mimemagic", "~> 0.4")


### PR DESCRIPTION
Front Signalwire Channel Replicator

This adds support for integrating Signalwire and Front
using Front Channels. Messages sent via Front are sent
via Signalwire, and messages sent to Signalwire
are imported into Front.

The design for this is documented in on the replicator,
but briefly, it acts like a replicator dependent on parents
of signalwire messages (so we can see inbound) and front resources
(so we can see outbound). Then this is like a 'two way sync',
where we send Signalwire SMS when we find a front outbound,
and import a Front message when we find a signalwire inbound.

---

Idempotency: Storage and separate connection

Use `.storage` to store (and retrieve stored) results.

We need this when making external mutation calls while
handling webhooks, like signalwire SMS and Front sync.

Use `.using_seperate_connection` to run the idempotency
(NOT the block) on a separate conn.

Required in some cases, especially when using storage.
Because the result is stored, we can be more granular with
the idempotency call. This is required when
we're in a transaction that we cannot get out of,
like when a lock is required on a row.

---

Signalwire send sms: Improve tests

And fix bug with non-allowlisted response.

---

ServiceIntegration#webhookdb_api_key column added

Also improve how the keys/ids are generated for
service integrations.

---

Service spec helpers: DELETE should be JSON too