### PR TITLE
ServiceIntegration add 'roll api key' endpoint and other fixes

### DIFF
--- a/lib/webhookdb/oauth/front_provider.rb
+++ b/lib/webhookdb/oauth/front_provider.rb
@@ -68,4 +68,8 @@ class Webhookdb::Oauth::FrontSignalwireChannelProvider < Webhookdb::Oauth::Front
   def app_name = "Front Signalwire Channel"
   def client_id = Webhookdb::Front.signalwire_channel_client_id
   def client_secret = Webhookdb::Front.signalwire_channel_client_secret
+
+  def build_marketplace_integrations(*)
+    raise NotImplementedError, "this should not be called, Front channels have a different setup"
+  end
 end

--- a/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
+++ b/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
@@ -134,10 +134,10 @@ Choose the phone number to connect to Front.)
     end
     self.service_integration.webhookdb_api_key ||= self.service_integration.new_api_key
     self.service_integration.save_changes
-    step.output = %(Almost there! You can now finish installing the WebhookDB - SignalWire Channel in Front.
+    step.output = %(Almost there! You can now finish installing the SignalWire Channel in Front.
 
 1. In Front, go to Settings -> Company -> Channels (in the left nav), Connect a Channel,
-   and choose the 'WebhookDB - SignalWire' channel.
+   and choose the 'WebhookDB/SignalWire' channel.
 2. In the 'Token' field, enter this API Key: #{self.service_integration.webhookdb_api_key}
 
 If you need to find this key, you can run `webhookdb integrations info front_signalwire_message_channel_app_v1`.
@@ -151,6 +151,12 @@ All of this information can be found in the WebhookDB docs, at https://docs.webh
     # They are procedurally enqueued when we upsert data.
     # So just reuse the webhook state machine.
     return self.calculate_webhook_state_machine
+  end
+
+  def clear_webhook_information
+    # We say we support backfill, so this won't get cleared normally.
+    self._clear_backfill_information
+    super
   end
 
   def process_webhooks_synchronously? = true

--- a/lib/webhookdb/service_integration.rb
+++ b/lib/webhookdb/service_integration.rb
@@ -9,8 +9,15 @@ class Webhookdb::ServiceIntegration < Webhookdb::Postgres::Model(:service_integr
   class TableRenameError < Webhookdb::InvalidInput; end
 
   # We limit the information that a user can access through the CLI to these fields.
-  # Blank string returns all info.
-  INTEGRATION_INFO_FIELDS = ["id", "service", "table", "url", "webhook_secret", ""].freeze
+  INTEGRATION_INFO_FIELDS = {
+    "id" => :opaque_id,
+    "service" => :service_name,
+    "table" => :table_name,
+    "url" => :unauthed_webhook_endpoint,
+    "webhook_secret" => :webhook_secret,
+    "webhookdb_api_key" => :webhookdb_api_key,
+    "api_url" => :api_url,
+  }.freeze
 
   plugin :timestamps
   plugin :column_encryption do |enc|

--- a/spec/webhookdb/api/service_integrations_spec.rb
+++ b/spec/webhookdb/api/service_integrations_spec.rb
@@ -618,6 +618,26 @@ RSpec.describe Webhookdb::API::ServiceIntegrations,
     end
   end
 
+  describe "POST /v1/organizations/:org_identifier/service_integrations/:opaque_id/roll_api_key" do
+    before(:each) do
+      login_as(customer)
+      _ = sint
+    end
+
+    it "replaces the existing api key" do
+      sint.update(webhookdb_api_key: "xyz")
+
+      post "/v1/organizations/#{org.key}/service_integrations/xyz/roll_api_key"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        webhookdb_api_key: start_with("sk"),
+      )
+
+      expect(sint.refresh).to have_attributes(webhookdb_api_key: start_with("sk"))
+    end
+  end
+
   describe "POST /v1/organizations/:org_identifier/service_integrations/:opaque_id/setup" do
     before(:each) do
       login_as(customer)

--- a/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
+++ b/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
@@ -412,6 +412,14 @@ RSpec.describe Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1, :db do
     end
   end
 
+  describe "clear_webhook_information" do
+    it "clears backfill info too" do
+      sint.api_url = "hi"
+      svc.clear_webhook_information
+      expect(sint).to have_attributes(api_url: "")
+    end
+  end
+
   describe "backfill", truncate: Webhookdb::Idempotency do
     support_phone = "2223334444"
     customer_phone = "5556667777"


### PR DESCRIPTION
Add assertion in case Front Signalwire is called via OAuth

---

ServiceIntegration add 'roll api key' endpoint

Needed in case the API key needs to be rolled.

Also fix some issues displaying `integration info`
(remove some duplication causing a bug).

Also clear backfill info when webhook fields are cleared
on the front signalwire channel.
