### PR TITLE
Front Signalwire: Remove marketplace dependency

### DIFF
--- a/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
+++ b/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
@@ -57,15 +57,6 @@ require "webhookdb/replicator/front_v1_mixin"
 #   - Find replication table rows without a Front message id, and create a Front message
 #     using https://dev.frontapp.com/reference/sync-inbound-message
 #
-# Note: This replicator depends on signalwire_message_v1, NOT front_marketplace_root_v1,
-# because 1) an org will only have one Front marketplace root, logically,
-# given how it is installed, so it can be reliably inferred,
-# 2) we can create the marketplace root replicator based on this one,
-# and especially 3) Front will ALWAYS hit this replicator webhook for messages;
-# SiWnWlWire may not, though, it depends on how the numebr is configured.
-# By being a dependency of signalwire_message_v1, the replicator is called whenever
-# a SignalWire row changes.
-#
 class Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1 < Webhookdb::Replicator::Base
   include Webhookdb::DBAdapter::ColumnTypes
 
@@ -116,17 +107,6 @@ class Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1 < Webhookdb::Rep
       return step
     end
     step = Webhookdb::Replicator::StateMachineStep.new
-    marketplace_root = self.service_integration.
-      organization.
-      service_integrations.
-      find { |si| si.service_name == "front_marketplace_root_v1" }
-    if marketplace_root.nil?
-      step.output = %(To set up Front Channels with WebhookDB,
-you must install the WebhookDB app from the Front App Store.
-Head over to https://front.com/integrations/webhookdb to set things up,
-and then try again.)
-      return step.completed
-    end
     if self.service_integration.api_url.blank?
       step.output = %(This Front Channel will be linked to a specific number in SignalWire.
 Choose the phone number to connect to Front.)

--- a/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
+++ b/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1, :db do
   let(:org) { Webhookdb::Fixtures.organization.create }
   let(:fac) { Webhookdb::Fixtures.service_integration(organization: org) }
   let(:signalwire_sint) { fac.create(service_name: "signalwire_message_v1") }
-  let(:frontapp_sint) { fac.create(service_name: "front_marketplace_root_v1") }
   let(:sint) { fac.depending_on(signalwire_sint).create(service_name:) }
   let(:svc) { sint.replicator }
 
@@ -355,25 +354,12 @@ RSpec.describe Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1, :db do
 
   describe "state machine calculation" do
     describe "calculate_webhook_state_machine" do
-      before(:each) do
-        _ = frontapp_sint
-      end
-
       it "requires for the signalwire dependency" do
         sint.update(depends_on: nil)
         signalwire_sint.destroy
         sm = sint.replicator.calculate_webhook_state_machine
         expect(sm).to have_attributes(
           output: include("This integration requires SignalWire Messages to sync"),
-          complete: true,
-        )
-      end
-
-      it "requires the front marketplace dependency" do
-        frontapp_sint.destroy
-        sm = sint.replicator.calculate_webhook_state_machine
-        expect(sm).to have_attributes(
-          output: include("you must install the WebhookDB app"),
           complete: true,
         )
       end
@@ -406,7 +392,7 @@ RSpec.describe Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1, :db do
       it "is the same as the webhook state machine" do
         sm = sint.replicator.calculate_backfill_state_machine
         expect(sm).to have_attributes(
-          output: include("To set up Front Channels with WebhookDB"),
+          output: include("You can now finish installing the SignalWire Channel in Front"),
         )
       end
     end


### PR DESCRIPTION
In the end, this wasn't required,
but was kept in for vestigial reasons.
This simplies the channel integration setup significantly.

Docs have also been updated.
