### PR TITLE
Add support for docker-based local development

### DIFF
--- a/.env.development.docker
+++ b/.env.development.docker
@@ -1,4 +1,0 @@
-DATABASE_URL=postgres://webhookdb:webhookdb@host.docker.internal:18005/webhookdb
-REDIS_URL=redis://host.docker.internal:18007/0
-SERVICE_ENFORCE_SSL=false
-WEBTERM_ENFORCE_SSL=false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,18 +8,52 @@ Sometimes the docs are on classes, sometimes they're here.
 We use the Makefile for every important development command since
 Makefiles are a wonderful high-level task runner.
 
-Dependencies are listed in `docker-compose.yml`.
+- This is set up as a standard Ruby (**not Rails**) app, and should work out of the box on most machines.
+- You can run with a local Ruby install, or through a 'development' Docker container.
+  - You can install the right Ruby version through `rbenv` (`.ruby-version`)
+    or `asdf` (`.tool-versions`), or you can run through Docker.
+  - If you run into problems with `make install` (usually due to native extension building),
+    you can try with the Docker container. It should be more reliable,
+    though is never as nice as true local development.
+- Service dependencies are listed in `docker-compose.yml`.
+  - We take a 'services are on localhost' approach, even in Docker.
+    It makes it much easier to work with the services, like using web interfaces.
+- The process (Ruby or Docker) needs to be restarted when you make changes.
+  We do not use an auto-reloader. Most development should be done with unit tests,
+  so iterating a live server should be rare.
 
-Otherwise, this is a pretty standard Ruby (**not Rails**) app.
-You can install the right Ruby version through `rbenv` (`.ruby-version`)
-or `asdf` (`.tool-versions`).
+Running with a local Ruby install:
 
 ```
-$ make install
-$ make up
-$ make test
-$ make run
-$ make run-workers
+$ make install    # Install gems and dependencies
+$ make up         # Start docker-compose services
+
+$ make migrate-test   # Migrate the test database
+$ make test           # Run unit tests
+
+$ make release                # Migrate the database
+$ make run                    # Runs the web process
+$ make run-workers            # Runs worker processes, you should do this in another window
+$ open http://localhost:18001 # Opens a browser to the hosted temrinal
+```
+
+Running with Docker, all of the above commands can be called with
+`make dockerdev-%` or `make dockertest-%`.
+The make target strings after `dockerdev-` and `dockertest-`
+are passed through to the underlying container (ie, `make dockertest-test` runs `make test`
+in the container, which is running with the proper environment.
+
+```
+$ make up                   # Start docker-compose services
+$ make dockerdev-build      # Build a dev/test container with gems built into it
+
+$ make dockertest-migrate-test   # Migrate the test database
+$ make dockertest-test           # Run tests
+
+$ make dockerdev-release         # Migrate the database
+$ make dockerdev-run             # Runs the web process
+$ make dockerdev-run-workers     # Runs worker process, you should do this another window
+$ open http://localhost:18001    # Opens a browser to the hosted temrinal
 ```
 
 ## Configuration

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:3.2.1-slim
+
+RUN apt-get update && apt-get install -y build-essential shared-mime-info libpq-dev git
+
+WORKDIR /app
+COPY .ruby-version .
+COPY .ruby-gemset .
+COPY Gemfile .
+COPY Gemfile.lock .
+COPY webhookdb.gemspec .
+COPY lib/webhookdb/version.rb lib/webhookdb/version.rb
+RUN bundle install
+COPY ./docker/docker-entrypoint.sh /docker-entrypoint.sh
+
+EXPOSE $PORT
+ENV DOCKER_DEV=true
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/lib/webhookdb.rb
+++ b/lib/webhookdb.rb
@@ -10,7 +10,21 @@ require "phony"
 
 require "webhookdb/json"
 
+if ENV["DOCKER_DEV"]
+  # If DOCKER_DEV is set, replace 'localhost' urls with 'host.docker.internal'.
+  ENV.each do |k, v|
+    begin
+      localhost = URI(v).host == "localhost"
+    rescue StandardError
+      next
+    end
+    next unless localhost
+    ENV[k] = v.gsub("localhost", "host.docker.internal")
+  end
+end
+
 if (heroku_app = ENV.fetch("MERGE_HEROKU_ENV", nil))
+  # If MERGE_HEROKU_ENV, merge all of its environment vars into the current env
   text = `heroku config -j --app=#{heroku_app}`
   json = Oj.load(text)
   json.each do |k, v|

--- a/lib/webhookdb/sync_target.rb
+++ b/lib/webhookdb/sync_target.rb
@@ -55,7 +55,7 @@ class Webhookdb::SyncTarget < Webhookdb::Postgres::Model(:sync_targets)
 
     after_configured do
       if Webhookdb::RACK_ENV == "test"
-        safename = ENV["USER"].gsub(/[^A-Za-z]/, "")
+        safename = ENV.fetch("USER", "root").gsub(/[^A-Za-z]/, "")
         self.default_schema = "synctest_#{safename}"
       end
     end

--- a/spec/webhookdb/organization/db_builder_spec.rb
+++ b/spec/webhookdb/organization/db_builder_spec.rb
@@ -3,6 +3,7 @@
 # rubocop:disable Layout/LineLength
 RSpec.describe Webhookdb::Organization::DbBuilder, :db, whdbisolation: :reset do
   let(:this_dbserver_url) { described_class.available_server_urls.first }
+  let(:dbhost) { URI(Webhookdb::Postgres::Model.uri).host } # do not hard-code localhost since we can be in a container
 
   describe "configuration", :whdbisolation do
     it "errors if there isolation mode is empty" do
@@ -41,8 +42,8 @@ RSpec.describe Webhookdb::Organization::DbBuilder, :db, whdbisolation: :reset do
       it "creates a randomly named database and connection strings and the public schema" do
         o.prepare_database_connections
         expect(o).to have_attributes(
-          admin_connection_url: %r(postgres://aad#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@localhost:18006/adb#{o.id}a[0-9a-f]{16}),
-          readonly_connection_url: %r(postgres://aro#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@localhost:18006/adb#{o.id}a[0-9a-f]{16}),
+          admin_connection_url: %r(postgres://aad#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@#{dbhost}:18006/adb#{o.id}a[0-9a-f]{16}),
+          readonly_connection_url: %r(postgres://aro#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@#{dbhost}:18006/adb#{o.id}a[0-9a-f]{16}),
           replication_schema: "public",
         )
       end
@@ -88,8 +89,8 @@ RSpec.describe Webhookdb::Organization::DbBuilder, :db, whdbisolation: :reset do
       it "creates a randomly named database and connection strings and the public schema" do
         o.prepare_database_connections
         expect(o).to have_attributes(
-          admin_connection_url: %r(postgres://aad#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@localhost:18006/adb#{o.id}a[0-9a-f]{16}),
-          readonly_connection_url: %r(postgres://aro#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@localhost:18006/adb#{o.id}a[0-9a-f]{16}),
+          admin_connection_url: %r(postgres://aad#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@#{dbhost}:18006/adb#{o.id}a[0-9a-f]{16}),
+          readonly_connection_url: %r(postgres://aro#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@#{dbhost}:18006/adb#{o.id}a[0-9a-f]{16}),
           replication_schema: "whdb_unit_test",
         )
       end
@@ -184,7 +185,7 @@ RSpec.describe Webhookdb::Organization::DbBuilder, :db, whdbisolation: :reset do
         o.prepare_database_connections
         expect(o).to have_attributes(
           admin_connection_url: this_dbserver_url,
-          readonly_connection_url: %r(postgres://aro#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@localhost:18006/webhookdb_test),
+          readonly_connection_url: %r(postgres://aro#{o.id}a[0-9a-f]{16}:a#{o.id}a[0-9a-f]{16}@#{dbhost}:18006/webhookdb_test),
           replication_schema: "whdb_unit_test",
         )
       end

--- a/spec/webhookdb/postgres/model_spec.rb
+++ b/spec/webhookdb/postgres/model_spec.rb
@@ -299,7 +299,8 @@ RSpec.describe "Webhookdb::Postgres::Model", :db do
 
     it "decrypts strings and uris" do
       st = Webhookdb::Fixtures.sync_target.postgres.create
-      expect(st.inspect).to include('connection_url: "postgres://*:*@localhost')
+      dbhost = URI(described_class.uri).host # do not hard-code localhost since we can be in a container
+      expect(st.inspect).to include(%(connection_url: "postgres://*:*@#{dbhost}))
       st.connection_url = "definitely not a url"
       expect(st.inspect).to include('connection_url: "def...url')
       st.connection_url = "abc"


### PR DESCRIPTION
From `DEVELOPMENT.md`:

We use the Makefile for every important development command since Makefiles are a wonderful high-level task runner.

- This is set up as a standard Ruby (**not Rails**) app, and should work out of the box on most machines.
- You can run with a local Ruby install, or through a 'development' Docker container.
  - You can install the right Ruby version through `rbenv` (`.ruby-version`) or `asdf` (`.tool-versions`), or you can run through Docker.
  - If you run into problems with `make install` (usually due to native extension building), you can try with the Docker container. It should be more reliable, though is never as nice as true local development.
- Service dependencies are listed in `docker-compose.yml`.
  - We take a 'services are on localhost' approach, even in Docker. It makes it much easier to work with the services, like using web interfaces.
- The process (Ruby or Docker) needs to be restarted when you make changes. We do not use an auto-reloader. Most development should be done with unit tests, so iterating a live server should be rare.

Running with a local Ruby install:

```
$ make install    # Install gems and dependencies
$ make up         # Start docker-compose services

$ make migrate-test   # Migrate the test database
$ make test           # Run unit tests

$ make release                # Migrate the database
$ make run                    # Runs the web process
$ make run-workers            # Runs worker processes, you should do this in another window
$ open http://localhost:18001 # Opens a browser to the hosted temrinal
```

Running with Docker, all of the above commands can be called with `make dockerdev-%` or `make dockertest-%`.
The make target strings after `dockerdev-` and `dockertest-` are passed through to the underlying container (ie, `make dockertest-test` runs `make test` in the container, which is running with the proper environment.

```
$ make up                   # Start docker-compose services
$ make dockerdev-build      # Build a dev/test container with gems built into it

$ make dockertest-migrate-test   # Migrate the test database
$ make dockertest-test           # Run tests

$ make dockerdev-release         # Migrate the database
$ make dockerdev-run             # Runs the web process
$ make dockerdev-run-workers     # Runs worker process, you should do this another window
$ open http://localhost:18001    # Opens a browser to the hosted temrinal
```