### PR TITLE
PrepareDatabaseConnections job is idempotent

### DIFF
--- a/lib/webhookdb/jobs/prepare_database_connections.rb
+++ b/lib/webhookdb/jobs/prepare_database_connections.rb
@@ -15,8 +15,8 @@ class Webhookdb::Jobs::PrepareDatabaseConnections
     org.db.transaction do
       # If creating the public host fails, we end up with an orphaned database,
       # but that's not a big deal- we can eventually see it's empty/unlinked and drop it.
-      org.prepare_database_connections
-      org.create_public_host_cname
+      org.prepare_database_connections(safe: true)
+      org.create_public_host_cname(safe: true)
     end
   end
 end

--- a/spec/webhookdb/organization/db_builder_spec.rb
+++ b/spec/webhookdb/organization/db_builder_spec.rb
@@ -277,9 +277,16 @@ RSpec.describe Webhookdb::Organization::DbBuilder, :db, whdbisolation: :reset do
       expect { o.create_public_host_cname }.to raise_error(Webhookdb::InvalidPrecondition, /must be set/)
     end
 
-    it "raises if public host is already set" do
-      assign_connection_urls(o, public_host: "already.set")
-      expect { o.create_public_host_cname }.to raise_error(Webhookdb::InvalidPrecondition, /must not be set/)
+    describe "when public host is already set" do
+      it "raises" do
+        assign_connection_urls(o, public_host: "already.set")
+        expect { o.create_public_host_cname }.to raise_error(Webhookdb::InvalidPrecondition, /must not be set/)
+      end
+
+      it "does not error if safe is used" do
+        assign_connection_urls(o, public_host: "already.set")
+        expect { o.create_public_host_cname(safe: true) }.to_not raise_error
+      end
     end
 
     it "creates the CNAME and sets the public host and cloudflare response" do


### PR DESCRIPTION
Use `safe: true` to avoid raising if urls or public host are already set.

Fixes #848 