### PR TITLE
Positive UTC offsets on local machines

### DIFF
--- a/lib/webhookdb/email_octopus.rb
+++ b/lib/webhookdb/email_octopus.rb
@@ -2,6 +2,8 @@
 
 require "appydays/configurable"
 
+require "webhookdb/crypto"
+
 module Webhookdb::EmailOctopus
   include Appydays::Configurable
 

--- a/lib/webhookdb/replicator/signalwire_message_v1.rb
+++ b/lib/webhookdb/replicator/signalwire_message_v1.rb
@@ -155,7 +155,9 @@ Press 'Show' next to the newly-created API token, and copy it.)
   def _fetch_backfill_page(pagination_token, last_backfilled:)
     urltail = pagination_token
     if pagination_token.blank?
-      date_send_max = Date.tomorrow
+      # We need to handle positive and negative UTC offset running locally (non-UTC).
+      # Using UTC + 1 day would give 'today' in some cases, we always want 'tomorrow the day after'.
+      date_send_max = (Time.now.utc + 2.days).to_date
       urltail = "/2010-04-01/Accounts/#{self.service_integration.backfill_key}/Messages.json" \
                 "?PageSize=100&DateSend%3C=#{date_send_max}"
     end

--- a/lib/webhookdb/replicator/twilio_sms_v1.rb
+++ b/lib/webhookdb/replicator/twilio_sms_v1.rb
@@ -128,7 +128,9 @@ Both of these values should be visible from the homepage of your Twilio admin Da
   def _fetch_backfill_page(pagination_token, last_backfilled:)
     url = "https://api.twilio.com"
     if pagination_token.blank?
-      date_send_max = Date.tomorrow
+      # We need to handle positive and negative UTC offset running locally (non-UTC).
+      # Using UTC + 1 day would give 'today' in some cases, we always want 'tomorrow the day after'.
+      date_send_max = (Time.now.utc + 2.days).to_date
       url += "/2010-04-01/Accounts/#{self.service_integration.backfill_key}/Messages.json" \
              "?PageSize=100&DateSend%3C=#{date_send_max}"
     else

--- a/spec/webhookdb/replicator/signalwire_message_v1_spec.rb
+++ b/spec/webhookdb/replicator/signalwire_message_v1_spec.rb
@@ -130,13 +130,13 @@ RSpec.describe Webhookdb::Replicator::SignalwireMessageV1, :db do
       R
     end
     def stub_service_request
-      return stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+      return stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
           with(headers: {"Authorization" => "Basic YmZrZXk6YmZzZWs="}).
           to_return(status: 200, body: success_body, headers: {})
     end
 
     def stub_service_request_error
-      stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey_wrong/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+      stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey_wrong/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
         with(headers: {"Authorization" => "Basic YmZrZXlfd3Jvbmc6YmZzZWs="}).
         to_return(status: 401, body: "", headers: {})
     end
@@ -282,7 +282,7 @@ RSpec.describe Webhookdb::Replicator::SignalwireMessageV1, :db do
 
     def stub_service_requests
       return [
-        stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+        stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
             with(headers: {"Authorization" => "Basic YmZrZXk6YmZzZWs="}).
             to_return(status: 200, body: page1_response, headers: {"Content-Type" => "application/json"}),
         stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/AC123/Messages.json?DateSent%3E=2008-01-02&From=%2B987654321&Page=1&PageSize=2&PageToken=PAMMc26223853f8c46b4ab7dfaa6abba0a26&To=%2B123456789").
@@ -294,13 +294,13 @@ RSpec.describe Webhookdb::Replicator::SignalwireMessageV1, :db do
 
     def stub_empty_requests
       return [
-        stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+        stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
             to_return(status: 200, body: page3_response, headers: {"Content-Type" => "application/json"}),
       ]
     end
 
     def stub_service_request_error
-      return stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+      return stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
           to_return(status: 402, body: "woah")
     end
   end
@@ -443,7 +443,7 @@ RSpec.describe Webhookdb::Replicator::SignalwireMessageV1, :db do
 
     def stub_service_requests(partial:)
       new_reqs = [
-        stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+        stub_request(:get, "https://whdbtestfake.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
           with(headers: {"Authorization" => "Basic YmZrZXk6YmZzZWs="}).
           to_return(status: 200, body: page1_response, headers: {"Content-Type" => "application/json"}),
       ]
@@ -516,7 +516,7 @@ RSpec.describe Webhookdb::Replicator::SignalwireMessageV1, :db do
       end
 
       def stub_service_request
-        return stub_request(:get, "https://fakespace.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+        return stub_request(:get, "https://fakespace.signalwire.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
             with(headers: {"Authorization" => "Basic YmZrZXk6YmZzZWs="}).
             to_return(status: 200, body: success_body, headers: {})
       end

--- a/spec/webhookdb/replicator/twilio_sms_v1_spec.rb
+++ b/spec/webhookdb/replicator/twilio_sms_v1_spec.rb
@@ -128,13 +128,13 @@ RSpec.describe Webhookdb::Replicator::TwilioSmsV1, :db do
       R
     end
     def stub_service_request
-      return stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+      return stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
           with(headers: {"Authorization" => "Basic YmZrZXk6YmZzZWs="}).
           to_return(status: 200, body: success_body, headers: {})
     end
 
     def stub_service_request_error
-      stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey_wrong/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+      stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey_wrong/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
         with(headers: {"Authorization" => "Basic YmZrZXlfd3Jvbmc6YmZzZWs="}).
         to_return(status: 401, body: "", headers: {})
     end
@@ -279,7 +279,7 @@ RSpec.describe Webhookdb::Replicator::TwilioSmsV1, :db do
 
     def stub_service_requests
       return [
-        stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+        stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
             with(headers: {"Authorization" => "Basic YmZrZXk6YmZzZWs="}).
             to_return(status: 200, body: page1_response, headers: {"Content-Type" => "application/json"}),
         stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Messages.json?DateSent%3E=2008-01-02&From=%2B987654321&Page=1&PageSize=2&PageToken=PAMMc26223853f8c46b4ab7dfaa6abba0a26&To=%2B123456789").
@@ -291,13 +291,13 @@ RSpec.describe Webhookdb::Replicator::TwilioSmsV1, :db do
 
     def stub_empty_requests
       return [
-        stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+        stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
             to_return(status: 200, body: page3_response, headers: {"Content-Type" => "application/json"}),
       ]
     end
 
     def stub_service_request_error
-      return stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+      return stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
           to_return(status: 402, body: "woah")
     end
   end
@@ -439,7 +439,7 @@ RSpec.describe Webhookdb::Replicator::TwilioSmsV1, :db do
 
     def stub_service_requests(partial:)
       new_reqs = [
-        stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+        stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
           with(headers: {"Authorization" => "Basic YmZrZXk6YmZzZWs="}).
           to_return(status: 200, body: page1_response, headers: {"Content-Type" => "application/json"}),
       ]
@@ -512,7 +512,7 @@ RSpec.describe Webhookdb::Replicator::TwilioSmsV1, :db do
       end
 
       def stub_service_request
-        return stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-23&PageSize=100").
+        return stub_request(:get, "https://api.twilio.com/2010-04-01/Accounts/bfkey/Messages.json?DateSend%3C=2020-11-24&PageSize=100").
             with(headers: {"Authorization" => "Basic YmZrZXk6YmZzZWs="}).
             to_return(status: 200, body: success_body, headers: {})
       end


### PR DESCRIPTION
Does not fail unit tests.

Twilio/Signalwire were using dates and not timestamps,
so it's probably better to use 'before two days from now',
since they don't document the timezone.

Fixes #853
