### PR TITLE
Icalendar: Improve operations of calendar syncs

### DIFF
--- a/lib/webhookdb/google_calendar.rb
+++ b/lib/webhookdb/google_calendar.rb
@@ -9,6 +9,12 @@ module Webhookdb::GoogleCalendar
     # How many calendars/events should we fetch in a single page?
     # Higher uses slightly more memory but fewer API calls.
     # Max of 2500.
+    #
+    # **NOTE:** Changing this in production will
+    # INVALIDATE EXISTING RESOURCES CAUSING A FULL RESYNC.
+    # You should, in general, avoid modifying this number once there is
+    # much Google Calendar data stored. Instead, page sizes will be automatically reduced
+    # as requests time out.
     setting :list_page_size, 2000
     # How many rows should we upsert at a time?
     # Higher is fewer upserts, but can create very large SQL strings,

--- a/lib/webhookdb/icalendar.rb
+++ b/lib/webhookdb/icalendar.rb
@@ -13,5 +13,11 @@ module Webhookdb::Icalendar
     # Do not store events older then this when syncing recurring events.
     # Many icalendar feeds are misconfigured and this prevents enumerating 2000+ years of recurrence.
     setting :oldest_recurring_event, "1990-01-01", convert: ->(s) { Date.parse(s) }
+    # Sync icalendar calendars only this often.
+    # Most services only update every day or so. Assume it takes 5s to sync each feed (request, parse, upsert).
+    # If you have 10,000 feeds, that is 50,000 seconds, or almost 14 hours of processing time,
+    # or two threads for 7 hours. The resyncs are spread out across the sync period
+    # (ie, no thundering herd every 8 hours), but it is still a good idea to sync as infrequently as possible.
+    setting :sync_period_hours, 6
   end
 end

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
@@ -3,6 +3,10 @@
 require "webhookdb/async/scheduled_job"
 require "webhookdb/jobs"
 
+# For every IcalendarCalendar row needing a sync (across all service integrations),
+# enqueue a +Webhookdb::Jobs::IcalendarSync+ job.
+# Jobs are 'splayed' over 1/4 of the configured calendar sync period (see +Webhookdb::Icalendar+)
+# to avoid a thundering herd.
 class Webhookdb::Jobs::IcalendarEnqueueSyncs
   extend Webhookdb::Async::ScheduledJob
 
@@ -10,12 +14,14 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
   splay 30
 
   def _perform
+    max_splay = Webhookdb::Icalendar.sync_period_hours.hours.to_i / 4
     Webhookdb::ServiceIntegration.dataset.where_each(service_name: "icalendar_calendar_v1") do |sint|
       sint.replicator.admin_dataset do |ds|
         sint.replicator.rows_needing_sync(ds).each do |row|
           calendar_external_id = row.fetch(:external_id)
           self.with_log_tags(sint.log_tags) do
-            enqueued_job_id = Webhookdb::Jobs::IcalendarSync.perform_async(sint.id, calendar_external_id)
+            splay = rand(1..max_splay)
+            enqueued_job_id = Webhookdb::Jobs::IcalendarSync.perform_in(splay, sint.id, calendar_external_id)
             self.logger.info("enqueued_icalendar_sync", calendar_external_id:, enqueued_job_id:)
           end
         end

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -125,10 +125,9 @@ The secret to use for signing is:
   end
 
   CLEANUP_SERVICE_NAMES = ["icalendar_event_v1"].freeze
-  SYNC_PERIOD = 4.hours
 
   def rows_needing_sync(dataset, now: Time.now)
-    cutoff = now - SYNC_PERIOD
+    cutoff = now - Webhookdb::Icalendar.sync_period_hours.hours
     return dataset.where(Sequel[last_synced_at: nil] | Sequel.expr { last_synced_at < cutoff })
   end
 


### PR DESCRIPTION
- Sync period is configurable
- Increase default period to 6 hours
- Distribute syncs over 1/4 of the sync period, avoid thundering herd
