### PR TITLE
Remove non-functional organization notification api params

### DIFF
--- a/lib/webhookdb/api/sync_targets.rb
+++ b/lib/webhookdb/api/sync_targets.rb
@@ -112,18 +112,14 @@ class Webhookdb::API::SyncTargets < Webhookdb::API::V1
             params do
               use :connection_url
               use :sync_target_params
-              optional :service_integration_opaque_id,
-                       type: String, allow_blank: false,
-                       desc: "This is a deprecated parameter. In the future, please use `service_integration_identifier`."
-              optional :service_integration_identifier, type: String, allow_blank: false
-              at_least_one_of :service_integration_opaque_id, :service_integration_identifier
+              requires :service_integration_identifier, type: String, allow_blank: false
             end
             route_setting :target_type, target_type_resource
             post :create do
               customer = current_customer
               org = lookup_org!(customer:)
               ensure_admin!(org, customer:)
-              identifier = params[:service_integration_identifier] || params[:service_integration_opaque_id]
+              identifier = params[:service_integration_identifier]
               sint = lookup_service_integration!(org, identifier)
 
               validate_period!(sint.organization, params[:period_seconds])

--- a/lib/webhookdb/api/webhook_subscriptions.rb
+++ b/lib/webhookdb/api/webhook_subscriptions.rb
@@ -6,46 +6,40 @@ class Webhookdb::API::WebhookSubscriptions < Webhookdb::API::V1
   resource :organizations do
     route_param :org_identifier, type: String do
       resource :webhook_subscriptions do
-        desc "Return all webhook subscriptions for the given org, and all integrations."
+        desc "Return all notifications for the given org and its integrations."
         get do
           org = lookup_org!
           subs = org.all_webhook_subscriptions
           message = ""
           if subs.empty?
             message = "Organization #{org.name} has no webhook subscriptions set up.\n" \
-                      "Use `webhookdb webhooks create` to set one up."
+                      "Use `webhookdb notifications create` to set one up."
           end
           status 200
           present_collection subs, with: Webhookdb::API::WebhookSubscriptionEntity, message:
         end
 
         params do
-          optional :url, prompt: "Enter the URL that WebhookDB should POST webhooks to:"
-          optional :webhook_secret, prompt: "Enter a random secret used to sign and verify webhooks to the given url:"
           optional :service_integration_identifier,
                    type: String,
-                   desc: "If provided, attach the webhook subscription to this integration rather than the org."
-          optional :service_integration_opaque_id,
-                   type: String,
-                   desc: "This is a deprecated parameter. In the future, please use `service_integration_identifier`."
+                   desc: "If provided, attach the webhook subscription to this integration rather than the org.",
+                   prompt: "Which integration is this for? Use the service name, table name, or opaque id.\n" \
+                           "See your integrations with `webhookdb integrations list`:"
+          optional :url, prompt: "Enter the URL that WebhookDB should POST notifications to:"
+          optional :webhook_secret,
+                   prompt: "Enter a random secret used to sign and verify notifications to the given url:"
         end
         post :create do
           org = lookup_org!
-          sint = nil
-          identifier = params[:service_integration_identifier] || params[:service_integration_opaque_id]
-          sint = lookup_service_integration!(org, identifier) if identifier.present?
+          sint = lookup_service_integration!(org, params[:service_integration_identifier])
+          url = params[:url]
           webhook_sub = Webhookdb::WebhookSubscription.create(
             webhook_secret: params[:webhook_secret],
-            deliver_to_url: params[:url],
-            organization: sint ? nil : org,
+            deliver_to_url: url,
             service_integration: sint,
             created_by: current_customer,
           )
-          message = if sint
-                      "All webhooks for this #{sint.service_name} integration will be sent to #{params[:url]}"
-          else
-            "All webhooks for all integrations belonging to organization #{org.name} will be sent to #{params[:url]}."
-          end
+          message = "All notifications for this #{sint.service_name} integration will be sent to #{url}"
           status 200
           present webhook_sub, with: Webhookdb::API::WebhookSubscriptionEntity, message:
         end

--- a/spec/webhookdb/api/sync_targets_spec.rb
+++ b/spec/webhookdb/api/sync_targets_spec.rb
@@ -99,37 +99,6 @@ RSpec.describe Webhookdb::API::SyncTargets, :db do
         )
       end
 
-      it "can use deprecated 'service_integration_opaque_id' parameter" do
-        post "/v1/organizations/#{org.key}/sync_targets/db/create",
-             service_integration_opaque_id: sint.opaque_id,
-             connection_url: valid_pg_url,
-             period_seconds: 600
-
-        expect(last_response).to have_status(200)
-      end
-
-      it "prefers 'service_integration_identifier' over 'service_integration_opaque_id' parameter" do
-        post "/v1/organizations/#{org.key}/sync_targets/db/create",
-             service_integration_identifier: sint.opaque_id,
-             service_integration_opaque_id: "fakesint",
-             connection_url: valid_pg_url,
-             period_seconds: 600
-
-        # if the deprecated param were used, this would be a 403 integration not found
-        expect(last_response).to have_status(200)
-      end
-
-      it "errors if no service integration id parameter has been submitted" do
-        post "/v1/organizations/#{org.key}/sync_targets/db/create",
-             connection_url: valid_pg_url,
-             period_seconds: 600
-
-        expect(last_response).to have_status(400)
-        expect(last_response).to have_json_body.that_includes(
-          error: include(message: match("at least one parameter must be provided")),
-        )
-      end
-
       it "403s if service integration with given identifier doesn't exist" do
         post "/v1/organizations/#{org.key}/sync_targets/db/create",
              service_integration_identifier: "fakesint", connection_url: "postgres://u:p@a.b", period_seconds: 600


### PR DESCRIPTION
Remove non-functional org notification endpoint

It was possible to create a notification (`WebhookSubscription`)
for organizations by leaving out the service integration identifier.
However, we don't yet properly support organization notifications,
so this would result in a busted notification.

This updates the endpoint that `webhookdb notifications create` uses
to prompt if the service integration identifier is not given;
in the future, once org webhooks are supported properly,
we can figure out how to create them on the CLI side.

Fixes https://github.com/webhookdb/webhookdb/issues/775
and closes https://github.com/webhookdb/webhookdb/pull/840

Also removes long-deprecated service_integration param on these endpoints

---

Sync target endpoints: Remove long-deprecated service_integration param
