### PR TITLE
Icalendar: Handle wrong encoding, handle 304s and 410s

### DIFF
--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -205,6 +205,10 @@ The secret to use for signing is:
       when Down::TooManyRedirects
         response_status = 301
         response_body = "<too many redirects>"
+      when Down::NotModified
+        # Do not alert on 304, but do log
+        self.logger.warn("icalendar_fetch_error", response_status: 304, request_url:, calendar_external_id:)
+        return
       when Down::TimeoutError, Down::SSLError, Down::ConnectionError, Down::InvalidUrl
         response_status = 0
         response_body = e.to_s

--- a/spec/data/icalendar/single_event_wrong_encoding.ics
+++ b/spec/data/icalendar/single_event_wrong_encoding.ics
@@ -1,0 +1,22 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:bsprodidfortestabc123
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+DTSTAMP:20050118T211523Z
+UID:bsuidfortestabc123
+DTSTART;TZID=US-Mountain:20050120T170000
+DTEND;TZID=US-Mountain:20050120T184500
+CLASS:PRIVATE
+GEO:37.386013;-122.0829322
+ORGANIZER;CN="Joe Bob: Magician":mailto:joebob@random.net
+PRIORITY:2
+SUMMARY:This is a really long summary to test the method of unfolding lines
+ \, so I'm just going to make it a whole bunch of lines. With a twist: a "
+ ö" takes up multiple bytes\, and should be wrapped to the next line.
+ATTACH:http://bush.sucks.org/impeach/him.rhtml
+ATTACH:http://corporations-dominate.existence.net/why.rhtml
+RDATE;TZID=US-Mountain:20050121T170000,20050122T170000
+X-TEST-COMPONENT;QTEST="Hello, World":Shouldn't double double quotes
+END:VEVENT
+END:VCALENDAR

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -505,6 +505,16 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
         end
       end
 
+      it "noops on Down 304 responses" do
+        Webhookdb::Fixtures.organization_membership.org(org).verified.admin.create
+        req = stub_request(:get, "https://feed.me").
+          and_return(status: 304)
+        row = insert_calendar_row(ics_url: "https://feed.me", external_id: "abc")
+        svc.sync_row(row)
+        expect(req).to have_been_made
+        expect(Webhookdb::Message::Delivery.all).to be_empty
+      end
+
       it "raises on unhandled Down http errors" do
         Webhookdb::Fixtures.organization_membership.org(org).verified.admin.create
         req = stub_request(:get, "https://feed.me").

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -1308,6 +1308,20 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
       end
     end
 
+    context "with busted, incorrect encoding" do
+      # This was generated with the following:
+      # iconv -f utf-8 -t iso-8859-1 < spec/data/icalendar/single_event.ics > spec/data/icalendar/single_event_wrong_encoding.ics
+      # See code for explanation.
+      let(:fn) { "single_event_wrong_encoding.ics" }
+
+      it "forces encoding to utf8" do
+        parsed = events
+        expect(parsed).to contain_exactly(
+          include("UID" => {"v" => "bsuidfortestabc123"}),
+        )
+      end
+    end
+
     context "event.ics" do
       let(:fn) { "event.ics" }
 


### PR DESCRIPTION
Icalendar: Handle incorrect encoding

We occassionally get incorrectly encoded files.
For example, the response may have a header:

    Content-Type: text/calendar; charset=UTF-8

but the actual encoding is not:

    file -I <filename>
    <filename>: text/calendar; charset=iso-8859-1

In these cases, there's not much we can do.
We can use chardet, but it's a big library and this issue
isn't common enough. Instead, try to force the encoding to utf-8,
which may break some things, but we'll see what happens.

---

ICalendar: 304s are handled

Only log them, rather than failing or alerting.

---

Icalendar: Do not alert on 410

Improve how 'handled' client errors are enumerated.