### PR TITLE
Manage views from WebhookDB

### DIFF
--- a/db/migrations/041_views.rb
+++ b/db/migrations/041_views.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:saved_views) do
+      primary_key :id
+      timestamptz :created_at, null: false, default: Sequel.function(:now)
+      timestamptz :updated_at
+
+      foreign_key :organization_id, :organizations, null: false, on_delete: :cascade
+      index :organization_id
+
+      text :name, null: false
+      unique [:organization_id, :name]
+      text :sql, null: false
+
+      foreign_key :created_by_id, :customers, null: true, on_delete: :set_null
+    end
+  end
+end

--- a/lib/webhookdb/api/saved_views.rb
+++ b/lib/webhookdb/api/saved_views.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "webhookdb/api"
+
+class Webhookdb::API::SavedViews < Webhookdb::API::V1
+  resource :organizations do
+    route_param :org_identifier do
+      resource :saved_views do
+        helpers do
+          def lookup_view!
+            org = lookup_org!
+            cq = org.saved_views_dataset[name: params[:name].strip]
+            merror!(403, "There is no view with that name.") if cq.nil?
+            return cq
+          end
+
+          def guard_editable!(customer, org)
+            return if has_admin?(org, customer:)
+            permission_error!("You must be an org admin to modify views.")
+          end
+        end
+
+        desc "Returns a list of all saved views associated with the org."
+        get do
+          views = lookup_org!.saved_views
+          message = ""
+          if views.empty?
+            message = "This organization doesn't have any saved views yet.\n" \
+                      "Use `webhookdb saved-view create` to set one up."
+          end
+          present_collection views, with: SavedViewEntity, message:
+        end
+
+        desc "Creates or replaces the view with the given name."
+        params do
+          optional :name,
+                   type: String,
+                   prompt: "Enter the view name (alphanumeric, spaces, underscores):"
+          optional :sql, type: String, prompt: "Enter the SQL you would like to run:"
+        end
+        post :create_or_replace do
+          cust = current_customer
+          org = lookup_org!
+          check_feature_access!(org, Webhookdb::SavedView.feature_role)
+          guard_editable!(cust, org)
+          begin
+            sv = Webhookdb::SavedView.create_or_replace(
+              organization: org,
+              sql: params[:sql],
+              name: params[:name].strip,
+              created_by: cust,
+            )
+          rescue Webhookdb::SavedView::InvalidQuery => e
+            Webhookdb::API::Helpers.prompt_for_required_param!(
+              request,
+              :sql,
+              "Enter a new query:",
+              output: "That query was invalid. #{e.message}\n" \
+                      "You can iterate on your query by connecting to your database from any SQL editor.\n" \
+                      "Use `webhookdb db connection` to get your query string.",
+            )
+          rescue Webhookdb::DBAdapter::InvalidIdentifier => e
+            Webhookdb::API::Helpers.prompt_for_required_param!(
+              request,
+              :name,
+              "Enter a new name:",
+              output: e.message,
+            )
+          end
+          message = "You have created or replaced the view with the name '#{sv.name}'. " \
+                    "You can now use it in any query with your database connection string. " \
+                    "Run `webhookdb db connection` to retrieve your connection string if you need it."
+          status 200
+          present sv, with: SavedViewEntity, message:
+        end
+
+        post :delete do
+          customer = current_customer
+          cq = lookup_view!
+          guard_editable!(customer, cq.organization)
+          cq.destroy
+          status 200
+          present cq, with: SavedViewEntity,
+                      message: "You have successfully deleted the saved view '#{cq.name}'."
+        end
+      end
+    end
+  end
+
+  class SavedViewEntity < Webhookdb::API::BaseEntity
+    expose :name
+
+    def self.display_headers
+      return [[:name, "Name"]]
+    end
+  end
+end

--- a/lib/webhookdb/apps.rb
+++ b/lib/webhookdb/apps.rb
@@ -18,6 +18,7 @@ require "webhookdb/api/me"
 require "webhookdb/api/organizations"
 require "webhookdb/api/replay"
 require "webhookdb/api/saved_queries"
+require "webhookdb/api/saved_views"
 require "webhookdb/api/service_integrations"
 require "webhookdb/api/services"
 require "webhookdb/api/stripe"
@@ -70,6 +71,7 @@ module Webhookdb::Apps
     mount Webhookdb::API::Organizations
     mount Webhookdb::API::Replay
     mount Webhookdb::API::SavedQueries
+    mount Webhookdb::API::SavedViews
     mount Webhookdb::API::ServiceIntegrations
     mount Webhookdb::API::Services
     mount Webhookdb::API::Stripe

--- a/lib/webhookdb/db_adapter/default_sql.rb
+++ b/lib/webhookdb/db_adapter/default_sql.rb
@@ -28,7 +28,7 @@ module Webhookdb::DBAdapter::DefaultSql
   def escape_identifier(s)
     s = s.to_s
     raise ArgumentError, "#{s} is an invalid identifier and should have been validated previously" unless
-      Webhookdb::DBAdapter::VALID_IDENTIFIER.match?(s)
+      Webhookdb::DBAdapter.valid_identifier?(s)
 
     quo = self.identifier_quote_char
     return "#{quo}#{s}#{quo}" if RESERVED_KEYWORDS.include?(s.upcase) ||

--- a/lib/webhookdb/fixtures/organizations.rb
+++ b/lib/webhookdb/fixtures/organizations.rb
@@ -20,6 +20,11 @@ module Webhookdb::Fixtures::Organizations
     Webhookdb::Fixtures.organization_membership.verified.create(customer: c, organization: self)
   end
 
+  decorator :with_admin, presave: true do |c={}|
+    c = Webhookdb::Fixtures.customer.create(c) unless c.is_a?(Webhookdb::Customer)
+    Webhookdb::Fixtures.organization_membership.verified.admin.create(customer: c, organization: self)
+  end
+
   decorator :with_invite, presave: true do |c={}|
     c = Webhookdb::Fixtures.customer.create(c) unless c.is_a?(Webhookdb::Customer)
     Webhookdb::Fixtures.organization_membership.invite.create(customer: c, organization: self)

--- a/lib/webhookdb/fixtures/saved_views.rb
+++ b/lib/webhookdb/fixtures/saved_views.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "webhookdb"
+require "webhookdb/fixtures"
+
+module Webhookdb::Fixtures::SavedViews
+  extend Webhookdb::Fixtures
+
+  fixtured_class Webhookdb::SavedView
+
+  base :saved_view do
+    self.name ||= "testview_#{SecureRandom.hex(3)}"
+    self.sql ||= "SELECT 'fixtured' AS testcol"
+  end
+
+  before_saving do |instance|
+    instance.organization ||= Webhookdb::Fixtures.organization.create
+    instance
+  end
+
+  decorator :created_by do |c={}|
+    c = Webhookdb::Fixtures.customer.create(c) unless c.is_a?(Webhookdb::Customer)
+    self.created_by = c
+  end
+end

--- a/lib/webhookdb/organization.rb
+++ b/lib/webhookdb/organization.rb
@@ -35,6 +35,7 @@ class Webhookdb::Organization < Webhookdb::Postgres::Model(:organizations)
               order: :id
   one_to_many :service_integrations, class: "Webhookdb::ServiceIntegration", order: :id
   one_to_many :saved_queries, class: "Webhookdb::SavedQuery", order: :id
+  one_to_many :saved_views, class: "Webhookdb::SavedView", order: :id
   one_to_many :webhook_subscriptions, class: "Webhookdb::WebhookSubscription", order: :id
   many_to_many :feature_roles, class: "Webhookdb::Role", join_table: :feature_roles_organizations, right_key: :role_id
   one_to_many :all_webhook_subscriptions,

--- a/lib/webhookdb/postgres.rb
+++ b/lib/webhookdb/postgres.rb
@@ -61,6 +61,7 @@ module Webhookdb::Postgres
     "webhookdb/organization_membership",
     "webhookdb/role",
     "webhookdb/saved_query",
+    "webhookdb/saved_view",
     "webhookdb/service_integration",
     "webhookdb/subscription",
     "webhookdb/sync_target",

--- a/lib/webhookdb/saved_view.rb
+++ b/lib/webhookdb/saved_view.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Webhookdb::SavedView < Webhookdb::Postgres::Model(:saved_views)
+  plugin :timestamps
+
+  DOCS_URL = "https://docs.webhookdb.com/docs/integrating/saved-views.html"
+
+  class InvalidQuery < Webhookdb::InvalidInput; end
+
+  many_to_one :organization, class: "Webhookdb::Organization"
+  many_to_one :created_by, class: "Webhookdb::Customer"
+
+  def self.feature_role
+    return Webhookdb.cached_get("saved-view-feature-role") do
+      Webhookdb::Role.find_or_create_or_find(name: "saved_views")
+    end
+  end
+
+  def self.create_or_replace(organization:, sql:, name:, **kw)
+    Webhookdb::DBAdapter.validate_identifier!(name, type: "view")
+    self.db.transaction do
+      sv = self.find_or_create_or_find(organization:, name:) do |new|
+        new.sql = sql
+      end
+      sv.update(sql:, **kw)
+
+      # Verify that the underlying query is readonly, by running it as a readonly user.
+      if (_, errmsg = organization.execute_readonly_query_with_help(sql)) && errmsg.present?
+        raise InvalidQuery, errmsg
+      end
+
+      # Create the view now that we've asserted it's readonly
+      qname = Webhookdb::DBAdapter::PG.new.escape_identifier(name)
+      organization.admin_connection do |conn|
+        conn << "CREATE OR REPLACE VIEW #{qname} AS (#{sql})"
+      end
+      return sv
+    end
+  end
+
+  def before_destroy
+    raise Webhookdb::InvariantViolation, "#{self.inspect} name became invalid somehow" unless
+      Webhookdb::DBAdapter.valid_identifier?(self.name)
+    if self.organization.admin_connection_url_raw.present?
+      qname = Webhookdb::DBAdapter::PG.new.escape_identifier(self.name)
+      self.organization.admin_connection do |conn|
+        conn << "DROP VIEW IF EXISTS #{qname}"
+      end
+    end
+    super
+  end
+end

--- a/lib/webhookdb/service/helpers.rb
+++ b/lib/webhookdb/service/helpers.rb
@@ -142,6 +142,11 @@ module Webhookdb::Service::Helpers
     merror!(403, message, code: "permission_check")
   end
 
+  def check_feature_access!(org, role)
+    return if org.feature_roles.include?(role)
+    permission_error!("This feature is not enabled for your organization.")
+  end
+
   # Raise a 400 error for unstructured validation.
   # @param errors [Array<String>,String] Error messages, like 'password is invalid'.
   # @param message [String] If not given, build it from the errors list.

--- a/lib/webhookdb/service/validators.rb
+++ b/lib/webhookdb/service/validators.rb
@@ -20,8 +20,7 @@ module Webhookdb::Service::Validators
     def validate_param!(attr_name, params)
       val = params[attr_name]
       return if val.blank? && @allow_blank
-      re = Webhookdb::DBAdapter::VALID_IDENTIFIER
-      return if re.match?(val)
+      return if Webhookdb::DBAdapter.valid_identifier?(val)
       raise Grape::Exceptions::Validation.new(
         params: [@scope.full_name(attr_name)],
         message: "is not a valid database identifier for WebhookDB. " +

--- a/lib/webhookdb/service_integration.rb
+++ b/lib/webhookdb/service_integration.rb
@@ -222,11 +222,7 @@ class Webhookdb::ServiceIntegration < Webhookdb::Postgres::Model(:service_integr
 
   def rename_table(to:)
     Webhookdb::Organization::DatabaseMigration.guard_ongoing!(self.organization)
-    unless Webhookdb::DBAdapter::VALID_IDENTIFIER.match?(to)
-      msg = "Sorry, this is not a valid table name. " + Webhookdb::DBAdapter::INVALID_IDENTIFIER_MESSAGE
-      msg += " And we see you what you did there ;)" if to.include?(";") && to.downcase.include?("drop")
-      raise TableRenameError, msg
-    end
+    Webhookdb::DBAdapter.validate_identifier!(to, type: "table")
     self.db.transaction do
       begin
         self.organization.admin_connection { |db| db << "ALTER TABLE #{self.table_name} RENAME TO #{to}" }

--- a/spec/webhookdb/api/saved_views_spec.rb
+++ b/spec/webhookdb/api/saved_views_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "webhookdb/api/saved_views"
+
+RSpec.describe Webhookdb::API::SavedViews, :db do
+  include Rack::Test::Methods
+
+  let(:app) { described_class.build_app }
+  let(:customer) { Webhookdb::Fixtures.customer.create }
+  let(:org) { Webhookdb::Fixtures.organization.with_admin(customer).create }
+
+  before(:each) do
+    login_as(customer)
+  end
+
+  describe "GET /v1/organizations/:key/saved_views" do
+    it "returns a list of saved views for the organization" do
+      sv = Webhookdb::Fixtures.saved_view(organization: org).create
+      Webhookdb::Fixtures.saved_view.create
+
+      get "/v1/organizations/#{org.key}/saved_views"
+
+      expect(last_response.status).to eq(200)
+      expect(last_response).to have_json_body.
+        that_includes(items: contain_exactly(include(name: sv.name)))
+    end
+
+    it "returns a message if organization has no saved views" do
+      new_org = Webhookdb::Fixtures.organization.with_member(customer).create
+      get "/v1/organizations/#{new_org.key}/saved_views"
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.
+        that_includes(message: include("have any saved views"))
+    end
+  end
+
+  describe "POST /v1/organizations/:key/saved_views/create_or_replace" do
+    before(:each) do
+      org.prepare_database_connections
+      org.add_feature_role(Webhookdb::SavedView.feature_role)
+    end
+
+    after(:each) do
+      org.remove_related_database
+    end
+
+    it "creates or replaces a view" do
+      post "/v1/organizations/#{org.key}/saved_views/create_or_replace", name: "myq", sql: "SELECT 1 AS x"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(name: "myq")
+      expect(org.saved_views).to contain_exactly(
+        have_attributes(created_by: customer, sql: "SELECT 1 AS x", name: "myq"),
+      )
+    end
+
+    it "fails if the SQL cannot be run" do
+      post "/v1/organizations/#{org.key}/saved_views/create_or_replace", name: "myq", sql: "SELECT invalid"
+
+      expect(last_response).to have_status(422)
+      expect(last_response).to have_json_body.that_includes(
+        error: include(state_machine_step: include(prompt: /new query/, output: /was invalid/)),
+      )
+    end
+
+    it "fails if the view name is invalid" do
+      post "/v1/organizations/#{org.key}/saved_views/create_or_replace", name: "hi-there", sql: "SELECT 1"
+
+      expect(last_response).to have_status(422)
+      expect(last_response).to have_json_body.that_includes(
+        error: include(state_machine_step: include(prompt: /new name/, output: /not a valid view name/)),
+      )
+    end
+
+    it "errors if the org does not have the saved_views feature role" do
+      org.remove_all_feature_roles
+
+      post "/v1/organizations/#{org.key}/saved_views/create_or_replace", name: "myq", sql: "SELECT 1 AS x"
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(error: include(message: /not enabled/))
+    end
+
+    it "errors if the user is not an admin" do
+      customer.verified_memberships.first.update(membership_role: Webhookdb::Role.non_admin_role)
+
+      post "/v1/organizations/#{org.key}/saved_views/create_or_replace", name: "myq", sql: "SELECT 1"
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(error: include(message: /admin to modify views/))
+    end
+  end
+
+  describe "POST /v1/organizations/:key/saved_views/delete" do
+    it "deletes the view with the given name" do
+      sv = Webhookdb::Fixtures.saved_view(organization: org).create
+
+      post "/v1/organizations/#{org.key}/saved_views/delete", {name: sv.name}
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        message: /deleted the saved view/,
+      )
+      expect(sv).to be_destroyed
+    end
+
+    it "403s if the query does not belong to the org or does not exist" do
+      sv = Webhookdb::Fixtures.saved_view.create
+
+      post "/v1/organizations/#{org.key}/saved_views/delete", {name: sv.name}
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(
+        error: include(message: /There is no view with that name/),
+      )
+    end
+
+    it "errors if the user is not an admin" do
+      sv = Webhookdb::Fixtures.saved_view(organization: org).create
+      customer.verified_memberships.first.update(membership_role: Webhookdb::Role.non_admin_role)
+
+      post "/v1/organizations/#{org.key}/saved_views/delete", {name: sv.name}
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(
+        error: include(message: /admin to modify views/),
+      )
+    end
+  end
+end

--- a/spec/webhookdb/organization/db_builder_spec.rb
+++ b/spec/webhookdb/organization/db_builder_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe Webhookdb::Organization::DbBuilder, :db, whdbisolation: :reset do
       it "errors for an invalid name" do
         expect do
           org.migrate_replication_schema("; drop table")
-        end.to raise_error(Webhookdb::Organization::SchemaMigrationError, /this is not a valid schema name/)
+        end.to raise_error(Webhookdb::DBAdapter::InvalidIdentifier, /this is not a valid schema name/)
       end
 
       it "errors if there is an ongoing migration" do

--- a/spec/webhookdb/saved_view_spec.rb
+++ b/spec/webhookdb/saved_view_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "webhookdb/saved_view"
+
+RSpec.describe "Webhookdb::SavedView", :db do
+  let(:described_class) { Webhookdb::SavedView }
+
+  it "has appropriate associations" do
+    cq = Webhookdb::Fixtures.saved_view.created_by.create
+    expect(cq).to have_attributes(
+      organization: be_a(Webhookdb::Organization),
+      created_by: be_a(Webhookdb::Customer),
+    )
+  end
+
+  describe ".create_or_replace" do
+    let(:org) { Webhookdb::Fixtures.organization.create }
+
+    after(:each) do
+      org.remove_related_database
+    end
+
+    it "creates a new view" do
+      org.prepare_database_connections
+      sva = described_class.create_or_replace(organization: org, sql: "SELECT 1 AS x", name: "testview")
+      expect(org.saved_views).to contain_exactly(be === sva)
+      expect(org.readonly_connection { |c| c[:testview].all }).to eq([{x: 1}])
+
+      svb = described_class.create_or_replace(organization: org, sql: "SELECT 1 AS y", name: "testview2")
+      expect(org.saved_views(reload: true)).to contain_exactly(be === sva, be === svb)
+      expect(org.readonly_connection { |c| c[:testview2].all }).to eq([{y: 1}])
+    end
+
+    it "replaces a view with the same name" do
+      org.prepare_database_connections
+      sv1 = described_class.create_or_replace(organization: org, sql: "SELECT 1 AS x", name: "testview")
+      sv2 = described_class.create_or_replace(organization: org, sql: "SELECT 2 AS x", name: "testview")
+      expect(sv2).to be === sv1
+      expect(org.saved_views).to contain_exactly(be === sv2)
+      expect(org.readonly_connection { |c| c[:testview].all }).to eq([{x: 2}])
+    end
+
+    it "escapes/quotes the name" do
+      org.prepare_database_connections
+      expect do
+        described_class.create_or_replace(organization: org, sql: "SELECT 1 AS z", name: "x y")
+      end.to_not raise_error
+      expect(org.readonly_connection { |c| c.select(Sequel.lit('* FROM "x y"')).all }).to eq([{z: 1}])
+    end
+
+    it "errors if the view name is not a valid identifier" do
+      expect do
+        described_class.create_or_replace(organization: org, sql: "SELECT 1", name: "hi-there")
+      end.to raise_error(Webhookdb::DBAdapter::InvalidIdentifier)
+    end
+
+    it "errors if the view query cannot run as readonly" do
+      org.prepare_database_connections
+      expect do
+        described_class.create_or_replace(organization: org, sql: "CREATE TABLE xyz(pk TEXT)", name: "testview")
+      end.to raise_error(described_class::InvalidQuery, /Queries must be read-only/)
+    end
+  end
+
+  describe "destroying" do
+    let(:org) { Webhookdb::Fixtures.organization.create }
+
+    after(:each) do
+      org.remove_related_database
+    end
+
+    it "drops the view if it exists" do
+      org.prepare_database_connections
+      sv = described_class.create_or_replace(organization: org, sql: "SELECT 1 AS x", name: "testview")
+      expect(org.readonly_connection { |c| c[:testview].all }).to have_length(1)
+      sv.destroy
+      expect { org.readonly_connection { |c| c[:testview].all } }.to raise_error(/relation "testview" does not exist/)
+    end
+
+    it "noops if the view does not exist" do
+      org.prepare_database_connections
+      sv = Webhookdb::Fixtures.saved_view.create(organization: org)
+      expect { sv.destroy }.to_not raise_error
+    end
+
+    it "errors if the view name is not a valid identifier" do
+      sv = Webhookdb::Fixtures.saved_view.create(organization: org, name: "hello-there")
+      expect { sv.destroy }.to raise_error(Webhookdb::InvariantViolation, /became invalid/)
+    end
+
+    it "noops if the org database has not been created" do
+      sv = Webhookdb::Fixtures.saved_view.create(organization: org)
+      expect { sv.destroy }.to_not raise_error
+    end
+  end
+end

--- a/spec/webhookdb/service_integration_spec.rb
+++ b/spec/webhookdb/service_integration_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Webhookdb::ServiceIntegration", :db do
     it "errors for an invalid name" do
       expect do
         sint.rename_table(to: "foo-bar")
-      end.to raise_error(described_class::TableRenameError, /must start with a letter/)
+      end.to raise_error(Webhookdb::DBAdapter::InvalidIdentifier, /must start with a letter/)
     end
 
     it "errors if the target table already exists" do


### PR DESCRIPTION
Add support for saved views

Give org admins the ability to manage views in their database
with a new command. It requires a view name and the SELECT query.

This should be safe as long as:

- We validate the view name (as we do for any identifier input)
- We run the SELECT query to verify it is readonly.
- Then we can build our own 'create or replace view' query
  using sanitized input.

However, I want to noodle on this a bit more to make sure
it's fully safe, so it's behind a feature role flag for now.

---

Unify some validation code

- Invalid DB identifiers should be handled in a single way
- Continue centralizing readonly query execution
