### PR TITLE
db/run_sql endpoint: add caching and GET

### DIFF
--- a/lib/webhookdb/service/middleware.rb
+++ b/lib/webhookdb/service/middleware.rb
@@ -42,7 +42,7 @@ module Webhookdb::Service::Middleware
         origins("*")
         resource "/v1/db/run_sql",
                  headers: :any,
-                 methods: [:post],
+                 methods: [:get, :post],
                  credentials: false,
                  expose: "*"
       end


### PR DESCRIPTION
- Use POST or GET on `/v1/db/run_sql`
- Add 5 minute http caching
- Add query_base64 to avoid weird url escaping with a raw query string
