### PR TITLE
Icalendar: Implicit end dates handled

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ Webhookdb::Fixtures.load_all
 RSpec.configure do |config|
   # config.full_backtrace = true
 
-  RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 600
+  RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 3000
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -705,9 +705,9 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
           END:VEVENT
         ICAL
         expect(sync(body)).to contain_exactly(
-          hash_including(compound_identity: "abc-c7614cff-3549-4a00-9152-d25cc1fe077d-0", start_at: Time.parse("2018-01-01 00:00:00Z"), end_at: nil),
-          hash_including(compound_identity: "abc-c7614cff-3549-4a00-9152-d25cc1fe077d-1", start_at: Time.parse("2019-01-01 00:00:00Z"), end_at: nil),
-          hash_including(compound_identity: "abc-c7614cff-3549-4a00-9152-d25cc1fe077d-2", start_at: Time.parse("2020-01-01 00:00:00Z"), end_at: nil),
+          hash_including(compound_identity: "abc-c7614cff-3549-4a00-9152-d25cc1fe077d-0", start_at: Time.parse("2018-01-01 00:00:00Z"), end_at: Time.parse("2018-01-01 00:00:00Z")),
+          hash_including(compound_identity: "abc-c7614cff-3549-4a00-9152-d25cc1fe077d-1", start_at: Time.parse("2019-01-01 00:00:00Z"), end_at: Time.parse("2019-01-01 00:00:00Z")),
+          hash_including(compound_identity: "abc-c7614cff-3549-4a00-9152-d25cc1fe077d-2", start_at: Time.parse("2020-01-01 00:00:00Z"), end_at: Time.parse("2020-01-01 00:00:00Z")),
         )
       end
 


### PR DESCRIPTION
This was missed in the spec-
if there is no DTEND, the behavior is still specified. So just set the DB value (end_at, end_date) based on the spec.

Fixes https://github.com/webhookdb/webhookdb/issues/869
