### PR TITLE
Backfill job: Do not allow multiple backfills

### DIFF
--- a/db/migrations/042_sint_lock.rb
+++ b/db/migrations/042_sint_lock.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:backfill_job_service_integration_locks) do
+      primary_key :id
+      foreign_key :service_integration_id, :service_integrations, null: false, on_delete: :cascade, unique: true
+    end
+  end
+end

--- a/lib/webhookdb/backfill_job.rb
+++ b/lib/webhookdb/backfill_job.rb
@@ -71,6 +71,12 @@ class Webhookdb::BackfillJob < Webhookdb::Postgres::Model(:backfill_jobs)
     self.child_jobs.each(&:enqueue)
   end
 
+  def ensure_service_integration_lock
+    return Webhookdb::BackfillJob::ServiceIntegrationLock.find_or_create_or_find(
+      service_integration_id: self.service_integration_id,
+    )
+  end
+
   #
   # :section: Sequel Hooks
   #

--- a/lib/webhookdb/backfill_job/service_integration_lock.rb
+++ b/lib/webhookdb/backfill_job/service_integration_lock.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Helper table so backfill jobs can take exclusive locks on a service integration.
+# Otherwise we end up backfilling the same integration concurrently.
+class Webhookdb::BackfillJob::ServiceIntegrationLock < Webhookdb::Postgres::Model(
+  :backfill_job_service_integration_locks,
+)
+
+  many_to_one :service_integration, class: "Webhookdb::ServiceIntegration"
+end

--- a/lib/webhookdb/postgres.rb
+++ b/lib/webhookdb/postgres.rb
@@ -48,6 +48,7 @@ module Webhookdb::Postgres
   # Require paths for all Sequel models used by the app.
   MODELS = [
     "webhookdb/backfill_job",
+    "webhookdb/backfill_job/service_integration_lock",
     "webhookdb/customer",
     "webhookdb/customer/reset_code",
     "webhookdb/database_document",


### PR DESCRIPTION
We were locking a backfill job, but allowing multiple backfill jobs for the same service integration.

Instead, if a service integration is currently being backfilled, immediately finish the new job.

Do this with a new lock-specific model,
since we do not want to lock updates to the service integration row. Otherwise it would block user interactions.
