### PR TITLE
Use admin instead of readonly dataset interally

### DIFF
--- a/lib/webhookdb/replicator/sponsy_v1_mixin.rb
+++ b/lib/webhookdb/replicator/sponsy_v1_mixin.rb
@@ -117,7 +117,7 @@ module Webhookdb::Replicator::SponsyV1Mixin
       self.find_api_key.blank?
 
     publications_svc = self.service_integration.depends_on.replicator
-    backfillers = publications_svc.readonly_dataset(timeout: :fast) do |pub_ds|
+    backfillers = publications_svc.admin_dataset(timeout: :fast) do |pub_ds|
       pub_ds = Webhookdb::Dbutil.reduce_expr(
         pub_ds,
         :|,

--- a/lib/webhookdb/sync_target.rb
+++ b/lib/webhookdb/sync_target.rb
@@ -327,7 +327,8 @@ class Webhookdb::SyncTarget < Webhookdb::Postgres::Model(:sync_targets)
     # it wasn't in the last sync; however that is likely not a big problem
     # since clients need to handle updates in any case.
     def dataset_to_sync
-      @replicator.readonly_dataset do |ds|
+      # Use admin dataset, since the client could be using all their readonly conns.
+      @replicator.admin_dataset do |ds|
         # Find rows updated before we started
         tscond = (@timestamp_expr <= @now)
         # Find rows updated after the last sync was run


### PR DESCRIPTION
We used readonly connections internally in a few places; since customers can have their user connection limit exhausted, this would cause errors in WebhookDB.

Instead, use the admin connection, which WebhookDB controls and is not used by customers.
