### PR TITLE
Signalwire-front channel: Alert admins on failure, fix dangling table on uninstall

### DIFF
--- a/data/messages/templates/errors/signalwire_send_sms.email.liquid
+++ b/data/messages/templates/errors/signalwire_send_sms.email.liquid
@@ -1,0 +1,31 @@
+{% expose subject %}WebhookDB: Signalwire SMS Error{% endexpose %}
+
+{% partial 'greeting' %}
+
+<p>
+    WebhookDB encountered an error trying to send an SMS via Signalwire using your credentials. We have the following information about the failure:
+</p>
+<ul>
+    <li>Service Integration Name: {{ service_name }}, ID: <code>{{ opaque_id }}</code></li>
+    <li>Request: <code>{{ request_method }} {{ request_url }}</code></li>
+    <li>Response Status: <code>{{ response_status }}</code></li>
+    <li>Body: <code>{{  response_body }}</code></li>
+</ul>
+<p>
+    Usually this indicates an API key has been revoked, or the parameters to your integration (like the 'from' number)
+    are incorrect, rather than being an error in WebhookDB itself.
+</p>
+<p>To fix this integration, head over to <a href="{{ app_url }}">{{ app_url }}</a>, log in, and run:</p>
+<pre>
+    webhookdb integrations reset {{ opaque_id }}
+</pre>
+<p>
+    If you no longer wish to use this integration, it can be deleted using:
+</p>
+<pre>
+    webhookdb integrations delete {{ opaque_id }}
+</pre>
+<p>We'll continue to send daily emails when this happens, so please do fix this up when you get a chance.</p>
+<p>Please file an issue at {{ oss_repo }} if you need any help.</p>
+
+{% partial 'signoff' %}

--- a/lib/webhookdb/messages/error_icalendar_fetch.rb
+++ b/lib/webhookdb/messages/error_icalendar_fetch.rb
@@ -21,8 +21,7 @@ class Webhookdb::Messages::ErrorIcalendarFetch < Webhookdb::Message::Template
   end
 
   def signature
-    ehash = Digest::MD5.hexdigest(@kw.to_s)
-    return "msg-#{self.full_template_name}-sint:#{@service_integration.id}-eid:#{@external_calendar_id}-err:#{ehash}"
+    return "msg-#{self.full_template_name}-sint:#{@service_integration.id}-eid:#{@external_calendar_id}"
   end
 
   def template_folder = "errors"

--- a/lib/webhookdb/messages/error_signalwire_send_sms.rb
+++ b/lib/webhookdb/messages/error_signalwire_send_sms.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "webhookdb/message/template"
+
+class Webhookdb::Messages::ErrorSignalwireSendSms < Webhookdb::Message::Template
+  def self.fixtured(_recipient)
+    sint = Webhookdb::Fixtures.service_integration.create
+    return self.new(
+      sint,
+      response_status: 422,
+      request_url: "https://whdbtest.signalwire.com/2010-04-01/Accounts/projid/Messages.json",
+      request_method: "POST",
+      response_body: {
+        code: "21717",
+        message: "From must belong to an active campaign.",
+        more_info: "https://developer.signalwire.com/compatibility-api/reference/error-codes",
+        status: 400,
+      }.to_json,
+    )
+  end
+
+  def initialize(service_integration, request_url:, request_method:, response_status:, response_body:)
+    @service_integration = service_integration
+    @request_url = request_url
+    @request_method = request_method
+    @response_status = response_status
+    @response_body = response_body
+    super()
+  end
+
+  def signature
+    return "msg-#{self.full_template_name}-sint:#{@service_integration.id}-req:#{@request_url}"
+  end
+
+  def template_folder = "errors"
+  def template_name = "signalwire_send_sms"
+
+  def liquid_drops
+    return super.merge(
+      service_name: @service_integration.service_name,
+      opaque_id: @service_integration.opaque_id,
+      request_method: @request_method,
+      request_url: @request_url,
+      response_status: @response_status,
+      response_body: @response_body,
+    )
+  end
+end

--- a/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
+++ b/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
@@ -148,7 +148,7 @@ All of this information can be found in the WebhookDB docs, at https://docs.webh
         self.service_integration.save_changes
         return {type: "success", webhook_url: "#{Webhookdb.api_url}/v1/install/front_signalwire/channel"}.to_json
       when "delete"
-        self.service_integration.destroy
+        self.service_integration.destroy_self_and_all_dependents
         return "{}"
       when "message", "message_autoreply"
         return {

--- a/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
+++ b/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
@@ -2,6 +2,7 @@
 
 require "jwt"
 
+require "webhookdb/messages/error_signalwire_send_sms"
 require "webhookdb/replicator/front_v1_mixin"
 
 # Front has a system of 'channels' but it is a challenge to use.
@@ -269,21 +270,55 @@ All of this information can be found in the WebhookDB docs, at https://docs.webh
           item[:signalwire_sid] = "skipped_due_to_age"
         else
           # send the SMS via signalwire
-          signalwire_resp = idempotency.execute do
-            Webhookdb::Signalwire.send_sms(
-              from: sender,
-              to: recipient,
-              body:,
-              space_url: @signalwire_sint.api_url,
-              project_id: @signalwire_sint.backfill_key,
-              api_key: @signalwire_sint.backfill_secret,
-              logger: @replicator.logger,
-            )
-          end
-          item[:signalwire_sid] = signalwire_resp.fetch("sid")
+          signalwire_resp = _send_sms(
+            idempotency,
+            from: sender,
+            to: recipient,
+            body:,
+          )
+          item[:signalwire_sid] = signalwire_resp.fetch("sid") if signalwire_resp
         end
       end
       @replicator.upsert_webhook_body(item.deep_stringify_keys)
+    end
+
+    def _send_sms(idempotency, from:, to:, body:)
+      return idempotency.execute do
+        Webhookdb::Signalwire.send_sms(
+          from:,
+          to:,
+          body:,
+          space_url: @signalwire_sint.api_url,
+          project_id: @signalwire_sint.backfill_key,
+          api_key: @signalwire_sint.backfill_secret,
+          logger: @replicator.logger,
+        )
+      end
+    rescue Webhookdb::Http::Error => e
+      response_body = e.body
+      response_status = e.status
+      request_url = e.uri.to_s
+      @replicator.logger.warn("signalwire_send_sms_error",
+                              response_body:, response_status:, request_url:, sms_from: from, sms_to: to,)
+      code = begin
+        # If this fails for whatever reason, or there is no 'code', re-raise the original error
+        e.response.parsed_response["code"]
+      rescue StandardError
+        nil
+      end
+      # All known codes are for the integrator, not on the webhookdb code side.
+      # https://developer.signalwire.com/guides/how-to-troubleshoot-common-messaging-issues
+      raise e if code.nil?
+
+      message = Webhookdb::Messages::ErrorSignalwireSendSms.new(
+        @replicator.service_integration,
+        response_status:,
+        response_body:,
+        request_url:,
+        request_method: "POST",
+      )
+      @replicator.service_integration.organization.alerting.dispatch_alert(message)
+      return nil
     end
 
     def _sync_front_inbound(sender:, texted_at:, item:, body:)

--- a/lib/webhookdb/tasks/message.rb
+++ b/lib/webhookdb/tasks/message.rb
@@ -28,7 +28,9 @@ module Webhookdb::Tasks
           SemanticLogger.add_appender(io: feedback_io)
 
           commit = Webhookdb::RACK_ENV != "test"
-          delivery = Webhookdb::Message::Delivery.preview(template_class_name.classify, commit:)
+          clsname = template_class_name.classify
+          (clsname += "s") if template_class_name.end_with?("s") && !clsname.end_with?("s")
+          delivery = Webhookdb::Message::Delivery.preview(clsname, commit:)
           feedback_io << "*** Created MessageDelivery: #{delivery.values}\n\n"
           feedback_io << delivery.body_with_mediatype!("text/plain")&.content
           feedback_io << "\n\n"

--- a/spec/data/signalwire/error_inactive_campaign.json
+++ b/spec/data/signalwire/error_inactive_campaign.json
@@ -1,0 +1,6 @@
+{
+  "code": "21717",
+  "message": "From must belong to an active campaign.",
+  "more_info": "https://developer.signalwire.com/compatibility-api/reference/error-codes",
+  "status": 400
+}

--- a/spec/webhookdb/message_spec.rb
+++ b/spec/webhookdb/message_spec.rb
@@ -117,4 +117,11 @@ RSpec.describe "Webhookdb::Message", :db, :messaging do
       )
     end
   end
+
+  it "can fixture all message templates" do
+    recipient = Webhookdb::Fixtures.customer.create
+    Webhookdb::Message::Template.subclasses.each do |cls|
+      expect { cls.fixtured(recipient) }.to_not raise_error
+    end
+  end
 end

--- a/spec/webhookdb/service_integration_spec.rb
+++ b/spec/webhookdb/service_integration_spec.rb
@@ -217,6 +217,11 @@ RSpec.describe "Webhookdb::ServiceIntegration", :db do
     ensure
       org.remove_related_database
     end
+
+    it "works if the database is not set up" do
+      sint.destroy_self_and_all_dependents
+      expect(org.service_integrations_dataset.all).to be_empty
+    end
   end
 
   describe "api key" do


### PR DESCRIPTION
Alert admins when signalwire cannot send an SMS

Do not raise in sentry since this an integration issue,
not a code issue.

---

Front-signalwire uninstall removes table

Should have been using `destroy_self_and_all_dependents`,
not just `destroy`.

Fixes #873
