### PR TITLE
OAuth and related cleanup

### DIFF
--- a/lib/webhookdb/api/organizations.rb
+++ b/lib/webhookdb/api/organizations.rb
@@ -54,7 +54,7 @@ class Webhookdb::API::Organizations < Webhookdb::API::V1
         get do
           _customer = current_customer
           org = lookup_org!
-          fake_entities = org.available_replicator_names.sort.map { |name| {name:} }
+          fake_entities = org.available_replicators.map(&:name).sort.map { |name| {name:} }
           message = "Run `webhookdb integrations create [service name]` to start replicating data to your database."
           present_collection fake_entities, with: Webhookdb::API::ServiceEntity, message:
         end

--- a/lib/webhookdb/api/service_integrations.rb
+++ b/lib/webhookdb/api/service_integrations.rb
@@ -41,7 +41,7 @@ class Webhookdb::API::ServiceIntegrations < Webhookdb::API::V1
         resource :create do
           helpers do
             def create_integration(org, name)
-              available_services_list = org.available_replicator_names.sort.join("\n\t")
+              available_services_list = org.available_replicators.map(&:name).sort.join("\n\t")
 
               service_name_invalid = Webhookdb::Replicator.registered(name).nil?
               if service_name_invalid
@@ -55,7 +55,7 @@ Run `webhookdb services list` to see available services, and try again with the 
               end
 
               # If org does not have access to the given service
-              unless org.available_replicator_names.include?(name)
+              unless org.available_replicators.map(&:name).include?(name)
                 step = Webhookdb::Replicator::StateMachineStep.new
                 step.needs_input = false
                 step.output =

--- a/lib/webhookdb/oauth.rb
+++ b/lib/webhookdb/oauth.rb
@@ -50,7 +50,8 @@ module Webhookdb::Oauth
     # Create the actual service integrations for the given org.
     # @param organization [Webhookdb::Organization]
     # @param tokens [Webhookdb::Oauth::Tokens]
-    # # @param scope [Hash]
+    # @param scope [Hash]
+    # @return [Webhookdb::ServiceIntegration]
     def build_marketplace_integrations(organization:, tokens:, scope:) = raise NotImplementedError
   end
   # rubocop:enable Lint/UnusedMethodArgument
@@ -74,6 +75,8 @@ module Webhookdb::Oauth
   end
 end
 
+require "webhookdb/oauth/fake_provider"
+Webhookdb::Oauth.register(Webhookdb::Oauth::FakeProvider)
 require "webhookdb/oauth/front_provider"
 Webhookdb::Oauth.register(Webhookdb::Oauth::FrontProvider)
 Webhookdb::Oauth.register(Webhookdb::Oauth::FrontSignalwireChannelProvider)

--- a/lib/webhookdb/oauth/fake_provider.rb
+++ b/lib/webhookdb/oauth/fake_provider.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "webhookdb/increase"
+
+class Webhookdb::Oauth::FakeProvider < Webhookdb::Oauth::Provider
+  class << self
+    attr_accessor :requires_webhookdb_auth
+  end
+
+  def key = "fake"
+  def app_name = "Fake"
+  def requires_webhookdb_auth? = Webhookdb::Oauth::FakeProvider.requires_webhookdb_auth
+  def supports_webhooks? = true
+
+  def authorization_url(state:)
+    return "#{Webhookdb.api_url}/v1/install/fake_oauth_authorization?client_id=fakeclient&state=#{state}"
+  end
+
+  def exchange_authorization_code(code:)
+    return Webhookdb::Oauth::Tokens.new(access_token: "access-#{code}", refresh_token: "refresh-#{code}")
+  end
+
+  def find_or_create_customer(tokens:, **)
+    return Webhookdb::Customer.find_or_create_for_email("#{tokens.access_token}@webhookdb.com")
+  end
+
+  def build_marketplace_integrations(organization:, tokens:, **)
+    return Webhookdb::ServiceIntegration.create_disambiguated(
+      "fake_v1",
+      organization:,
+      webhook_secret: tokens.access_token,
+      backfill_key: tokens.refresh_token,
+    )
+  end
+end

--- a/lib/webhookdb/oauth/front_provider.rb
+++ b/lib/webhookdb/oauth/front_provider.rb
@@ -60,6 +60,7 @@ class Webhookdb::Oauth::FrontProvider < Webhookdb::Oauth::Provider
       backfill_key: tokens.refresh_token,
     )
     root_sint.replicator.build_dependents
+    return root_sint
   end
 end
 

--- a/lib/webhookdb/oauth/intercom_provider.rb
+++ b/lib/webhookdb/oauth/intercom_provider.rb
@@ -54,5 +54,6 @@ class Webhookdb::Oauth::IntercomProvider < Webhookdb::Oauth::Provider
       backfill_key: tokens.access_token,
     )
     root_sint.replicator.build_dependents
+    return root_sint
   end
 end

--- a/lib/webhookdb/organization.rb
+++ b/lib/webhookdb/organization.rb
@@ -472,7 +472,7 @@ class Webhookdb::Organization < Webhookdb::Postgres::Model(:organizations)
     return Webhookdb::ServiceIntegration.where(organization: self).count < limit
   end
 
-  def available_replicator_names
+  def available_replicators
     available = Webhookdb::Replicator.registry.values.filter do |desc|
       # The org must have any of the flags required for the service. In other words,
       # the intersection of desc[:feature_roles] & org.feature_roles must
@@ -482,7 +482,7 @@ class Webhookdb::Organization < Webhookdb::Postgres::Model(:organizations)
       org_has_access = (self.feature_roles.map(&:name) & desc.feature_roles).present?
       org_has_access
     end
-    return available.map(&:name)
+    return available
   end
 
   #

--- a/lib/webhookdb/spec_helpers/shared_examples_for_replicators.rb
+++ b/lib/webhookdb/spec_helpers/shared_examples_for_replicators.rb
@@ -45,7 +45,7 @@ RSpec.shared_examples "a replicator" do |name|
       if expected_row
         expect(ds.first).to match(expected_row)
       else
-        expect(ds.first[:data]).to eq(expected_data)
+        expect(ds.first[:data].to_h).to eq(expected_data)
       end
     end
   end
@@ -59,7 +59,7 @@ RSpec.shared_examples "a replicator" do |name|
       if expected_row
         expect(ds.first).to match(expected_row)
       else
-        expect(ds.first[:data]).to eq(expected_data)
+        expect(ds.first[:data].to_h).to eq(expected_data)
       end
       # this is how a fully qualified table is represented (schema->table, table->column)
       expect(ds.opts[:from].first).to have_attributes(table: "xyz", column: svc.service_integration.table_name.to_sym)
@@ -277,7 +277,7 @@ RSpec.shared_examples "a replicator that prevents overwriting new data with old"
       if expected_old_row
         expect(ds.first).to match(expected_old_row)
       else
-        expect(ds.first[:data]).to eq(expected_old_data)
+        expect(ds.first[:data].to_h).to eq(expected_old_data)
       end
 
       upsert_webhook(svc, body: new_body)
@@ -285,7 +285,7 @@ RSpec.shared_examples "a replicator that prevents overwriting new data with old"
       if expected_new_row
         expect(ds.first).to match(expected_new_row)
       else
-        expect(ds.first[:data]).to eq(expected_new_data)
+        expect(ds.first[:data].to_h).to eq(expected_new_data)
       end
     end
   end
@@ -299,7 +299,7 @@ RSpec.shared_examples "a replicator that prevents overwriting new data with old"
       if expected_new_row
         expect(ds.first).to match(expected_new_row)
       else
-        expect(ds.first[:data]).to eq(expected_new_data)
+        expect(ds.first[:data].to_h).to eq(expected_new_data)
       end
 
       upsert_webhook(svc, body: old_body)
@@ -307,7 +307,7 @@ RSpec.shared_examples "a replicator that prevents overwriting new data with old"
       if expected_new_row
         expect(ds.first).to match(expected_new_row)
       else
-        expect(ds.first[:data]).to eq(expected_new_data)
+        expect(ds.first[:data].to_h).to eq(expected_new_data)
       end
     end
   end
@@ -475,7 +475,7 @@ RSpec.shared_examples "a replicator that deals with resources and wrapped events
     upsert_webhook(svc, body: resource_json, headers: resource_headers)
     svc.readonly_dataset do |ds|
       expect(ds.all).to have_length(1)
-      expect(ds.first[:data]).to eq(resource_json)
+      expect(ds.first[:data].to_h).to eq(resource_json)
     end
   end
 
@@ -484,7 +484,7 @@ RSpec.shared_examples "a replicator that deals with resources and wrapped events
     upsert_webhook(svc, body: resource_in_envelope_json, headers: resource_in_envelope_headers)
     svc.readonly_dataset do |ds|
       expect(ds.all).to have_length(1)
-      expect(ds.first[:data]).to eq(resource_json)
+      expect(ds.first[:data].to_h).to eq(resource_json)
     end
   end
 end

--- a/spec/data/intercom/token_response.json
+++ b/spec/data/intercom/token_response.json
@@ -1,5 +1,5 @@
 {
   "token_type": "Bearer",
   "token": "intercom_auth_token",
-  "access_token": "intercom_auth_token"
+  "access_token": "intercom_access_token"
 }

--- a/spec/webhookdb/oauth/front_provider_spec.rb
+++ b/spec/webhookdb/oauth/front_provider_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "webhookdb/oauth"
+
+RSpec.describe Webhookdb::Oauth::FrontProvider, :db do
+  let(:customer) { Webhookdb::Fixtures.customer.create }
+  let(:org) { Webhookdb::Fixtures.organization.with_member(customer).create }
+  let(:front_instance_api_url) { "webhookdb_test.api.frontapp.com" }
+  let(:provider) { Webhookdb::Oauth.provider("front") }
+
+  describe "exchange_authorization_code" do
+    def stub_auth_token_request
+      body = {
+        "code" => "front_test_auth",
+        "redirect_uri" => "http://localhost:18001/v1/install/front/callback",
+        "grant_type" => "authorization_code",
+      }.to_json
+      return stub_request(:post, "https://app.frontapp.com/oauth/token").with(body:).
+          to_return(json_response(load_fixture_data("front/auth_token_response")))
+    end
+
+    it "calls the provider" do
+      req = stub_auth_token_request
+      tokens = provider.exchange_authorization_code(code: "front_test_auth")
+      expect(tokens).to have_attributes(access_token: "AYjcyMzY3ZDhiNmJkNTY", refresh_token: "RjY2NjM5NzA2OWJjuE7c")
+      expect(req).to have_been_made
+    end
+  end
+
+  describe "build_marketplace_integrations" do
+    let(:tokens) do
+      Webhookdb::Oauth::Tokens.new(
+        access_token: "AYjcyMzY3ZDhiNmJkNTY", refresh_token: "RjY2NjM5NzA2OWJjuE7c",
+      )
+    end
+
+    before(:each) do
+      org.prepare_database_connections
+    end
+
+    after(:each) do
+      org.remove_related_database
+    end
+
+    def stub_token_info_request
+      return stub_request(:get, "https://api2.frontapp.com/me").
+          to_return(json_response(load_fixture_data("front/token_info_response")))
+    end
+
+    it "builds integrations" do
+      req = stub_token_info_request
+      root_sint = provider.build_marketplace_integrations(organization: org, tokens:, scope: nil)
+      expect(req).to have_been_made
+      expect(root_sint).to have_attributes(organization: be === org, service_name: "front_marketplace_root_v1")
+      expect(org.refresh.service_integrations).to contain_exactly(
+        have_attributes(
+          service_name: "front_marketplace_root_v1",
+          api_url: front_instance_api_url,
+          # We can't match on an encrypted field, but the backfill_key of the root should be the
+          # Front refresh token. We can just test that the field isn't nil
+          backfill_key: not_be_nil,
+        ),
+        have_attributes(service_name: "front_message_v1"),
+        have_attributes(service_name: "front_conversation_v1"),
+      )
+    end
+  end
+
+  describe "SignalwireProvider" do
+    describe "build_marketplace_integrations" do
+      it "are not implemented" do
+        p = Webhookdb::Oauth.provider("front_signalwire")
+        expect do
+          p.build_marketplace_integrations(organization: nil, scope: nil, tokens: nil)
+        end.to raise_error(NotImplementedError, /Front channels have a different setup/)
+      end
+    end
+  end
+end

--- a/spec/webhookdb/oauth/intercom_provider_spec.rb
+++ b/spec/webhookdb/oauth/intercom_provider_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "webhookdb/oauth"
+
+RSpec.describe Webhookdb::Oauth::IntercomProvider, :db do
+  let(:customer) { Webhookdb::Fixtures.customer.create }
+  let(:org) { Webhookdb::Fixtures.organization.with_member(customer).create }
+  let(:provider) { Webhookdb::Oauth.provider("intercom") }
+
+  describe "exchange_authorization_code" do
+    def stub_auth_token_request
+      return stub_request(:post, "https://api.intercom.io/auth/eagle/token").
+          to_return(json_response(load_fixture_data("intercom/token_response")))
+    end
+
+    it "calls the provider" do
+      req = stub_auth_token_request
+      tokens = provider.exchange_authorization_code(code: "intercom_test_auth")
+      expect(tokens).to have_attributes(access_token: "intercom_auth_token", refresh_token: nil)
+      expect(req).to have_been_made
+    end
+  end
+
+  describe "find_or_create_customer" do
+    let(:tokens) { Webhookdb::Oauth::Tokens.new(access_token: "intercom_auth_token", refresh_token: nil) }
+
+    let(:user_resp) { load_fixture_data("intercom/get_user") }
+
+    def stub_token_info_request
+      return stub_request(:get, "https://api.intercom.io/me").
+          to_return(json_response(user_resp))
+    end
+
+    it "finds or creates a user with the intercom email" do
+      req = stub_token_info_request
+      scope = {}
+      created, cust = provider.find_or_create_customer(tokens:, scope:)
+      expect(req).to have_been_made
+      expect(created).to be(true)
+      expect(cust).to have_attributes(email: "ginger@example.com")
+      expect(scope).to include(me_response: user_resp)
+    end
+  end
+
+  describe "build_marketplace_integrations" do
+    let(:tokens) { Webhookdb::Oauth::Tokens.new(access_token: "intercom_auth_token", refresh_token: nil) }
+
+    before(:each) do
+      org.prepare_database_connections
+    end
+
+    after(:each) do
+      org.remove_related_database
+    end
+
+    it "builds integrations" do
+      scope = {me_response: load_fixture_data("intercom/get_user")}
+      root_sint = provider.build_marketplace_integrations(organization: org, tokens:, scope:)
+      expect(root_sint).to have_attributes(organization: be === org, service_name: "intercom_marketplace_root_v1")
+      expect(org.refresh.service_integrations).to contain_exactly(
+        have_attributes(
+          service_name: "intercom_marketplace_root_v1",
+          api_url: "lithic_tech_intercom_abc",
+          backfill_key: not_be_nil,
+        ),
+        have_attributes(service_name: "intercom_conversation_v1"),
+        have_attributes(service_name: "intercom_contact_v1"),
+      )
+
+      expect(Webhookdb::BackfillJob.all).to contain_exactly(
+        have_attributes(
+          service_integration: have_attributes(service_name: "intercom_contact_v1"),
+          incremental: true,
+        ),
+        have_attributes(
+          service_integration: have_attributes(service_name: "intercom_conversation_v1"),
+          incremental: true,
+        ),
+      )
+    end
+  end
+end

--- a/spec/webhookdb/organization_spec.rb
+++ b/spec/webhookdb/organization_spec.rb
@@ -415,13 +415,13 @@ RSpec.describe "Webhookdb::Organization", :async, :db do
     it "filters out replicators that the org should not have access to" do
       # by default the org does not have the "internal" feature role assigned to it,
       # so our "fake" integrations should not show up in this list
-      expect(o.available_replicator_names).to_not include("fake_v1", "fake_with_enrichments_v1")
+      expect(o.available_replicators.map(&:name)).to_not include("fake_v1", "fake_with_enrichments_v1")
     end
 
     it "includes replicators that the org should have access to" do
       internal_role = Webhookdb::Role.create(name: "internal")
       o.add_feature_role(internal_role)
-      expect(o.available_replicator_names).to include("fake_v1", "fake_with_enrichments_v1")
+      expect(o.available_replicators.map(&:name)).to include("fake_v1", "fake_with_enrichments_v1")
     end
   end
 end


### PR DESCRIPTION
While switching the Increase replicators to use OAuth, I had to make these incidental improvements. They're in a separate PR to reduce the Increase diff, since they are internal and testing refactors.

---

Use `#to_h` when asserting `:data` column

PGJson doesn't compare equality against a hash,
which is confusing, because the string representation
makes them seem equal.

---

Overhaul OAuth testing

- Add a 'fake' provider
- Do all testing with the fake provider,
  eliminates implicit dependency on behavior of Front
  and Intercom (requires and does not require WHDB auth).
- Test specific OAuth providers explicitly

---

Rename #available_replicator_names to #available_replicators

