### PR TITLE
Overhaul OAuth flow

### DIFF
--- a/data/messages/web/install-customer-login.liquid
+++ b/data/messages/web/install-customer-login.liquid
@@ -1,6 +1,7 @@
 <html lang="en-US">
 <head>
-    {% include 'web/styles' %}
+    <title>WebhookDB | Sync {{ app_name }} | Login</title>
+    {% include 'web/partials/head' %}
 </head>
 <body>
 <div class="layout">
@@ -11,12 +12,12 @@
             <form method="POST" action="{{ action_url }}">
                 {% if view == "email" %}
                     <p>
-                        Welcome to WebhookDB! In order to complete this integration, we need your email address so that
-                        we can associate your information with an organization.
+                        Welcome to WebhookDB! In order to finish your sync with {{ app_name }},
+                        you need to sign up or log in.
                     </p>
                     <p>Enter your email:</p>
                     <div class="input-group">
-                        <input class="input-inline" type="text" id="email" name="email"/>
+                        <input class="input-inline" type="text" id="email" name="email" autofocus/>
                         <input class="input-inline-button" type="submit" value="Log in"/>
                     </div>
                     {% partial 'web/partials/form_error' %}
@@ -31,7 +32,7 @@
                     </p>
                     <p>Enter the token from your email:</p>
                     <div class="input-group">
-                        <input class="input-inline" type="text" id="otp_token" name="otp_token"/>
+                        <input class="input-inline" type="text" id="otp_token" name="otp_token" autofocus/>
                         <input class="input-inline-button" type="submit" value="Log in"/>
                     </div>
                     {% partial 'web/partials/form_error' %}

--- a/data/messages/web/install-error.liquid
+++ b/data/messages/web/install-error.liquid
@@ -1,6 +1,6 @@
 <html lang="en-US">
 <head>
-    {% include 'web/styles' %}
+    {% include 'web/partials/head' %}
 </head>
 <body>
 <div class="layout">

--- a/data/messages/web/install-forbidden.liquid
+++ b/data/messages/web/install-forbidden.liquid
@@ -1,0 +1,25 @@
+<html lang="en-US">
+<head>
+    <title>WebhookDB | Sync {{ app_name }} | Error</title>
+    {% include 'web/partials/head' %}
+</head>
+<body>
+<div class="layout">
+    <div class="flex column align-items-center content">
+        {% partial 'web/partials/header' %}
+        <div class="flex column">
+            <p>
+                Sorry, something went wrong installing your sync to {{ app_name }}.
+            </p>
+            <p>
+                If your installation finished successfully, head to <a href="{{ terminal_url }}">{{ terminal_url }}</a>
+                and run <code>webhookdb auth login</code> and <code>webhookdb db connection</code> to get your connection string.
+            </p>
+            <p>Or head to <a href="{{ install_url }}">{{ install_url }}</a> to go back through setup.</p>
+            <p>If you need any help, you can email <a href="mailto:hello@webhookdb.com">hello@webhookdb.com</a>.</p>
+        </div>
+        {% partial 'web/partials/footer' %}
+    </div>
+</div>
+</body>
+</html>

--- a/data/messages/web/install-org-chooser.liquid
+++ b/data/messages/web/install-org-chooser.liquid
@@ -1,0 +1,40 @@
+<html lang="en-US">
+<head>
+    <title>WebhookDB | Sync {{ app_name }} | Choose Organization</title>
+    {% include 'web/partials/head' %}
+</head>
+<body>
+<div class="layout">
+    <div class="flex column align-items-center content">
+        {% partial 'web/partials/header' %}
+
+        <div class="mt-2">
+            <form method="POST" action="{{ action_url }}">
+                <p>
+                    Choose which WebhookDB organization your {{ app_name }} data will be replicated to.
+                    You can also create a new organization (and database) to hold this data.
+                </p>
+                <div class="input-radio-group">
+                    {% for org in organizations %}
+                    <div class="input-radio-control">
+                        <input type="radio" id="org-{{ org.key }}" name="existing_org_key" value="{{ org.key }}" checked="{{ org.checked }}" />
+                        <label for="org-{{ org.key }}">{{ org.name }}</label>
+                    </div>
+                    {% endfor %}
+                    <div class="input-radio-control">
+                        <input type="radio" id="new_org" name="existing_org_key" value=""/>
+                        <label for="new_org">Create an Organization:</label>
+                        <input id="new_org_name" type="text" name="new_org_name" aria-labelledby="new_org" onfocus="document.querySelector('#new_org').checked = true">
+                    </div>
+                </div>
+                <input class="button w-100" type="submit" value="Submit"/>
+                {% partial 'web/partials/form_error' %}
+                <input type="hidden" id="state" name="state" value="{{ oauth_state }}">
+            </form>
+
+        </div>
+        {% partial 'web/partials/footer' %}
+    </div>
+</div>
+</body>
+</html>

--- a/data/messages/web/install-success.liquid
+++ b/data/messages/web/install-success.liquid
@@ -1,6 +1,7 @@
 <html lang="en-US">
 <head>
-    {% include 'web/styles' %}
+    <title>WebhookDB | Sync {{ app_name }} | Success!</title>
+    {% include 'web/partials/head' %}
 </head>
 <body>
 <div class="layout">

--- a/data/messages/web/install.liquid
+++ b/data/messages/web/install.liquid
@@ -1,6 +1,7 @@
 <html lang="en-US">
 <head>
-    {% include 'web/styles' %}
+    <title>WebhookDB | Sync {{ app_name }}</title>
+    {% include 'web/partials/head' %}
 </head>
 <body>
 <div class="layout">

--- a/data/messages/web/partials/head.liquid
+++ b/data/messages/web/partials/head.liquid
@@ -1,0 +1,2 @@
+<link rel="icon" href="/terminal/favicon.ico" type="image/x-icon" />
+{% include 'web/styles' %}

--- a/data/messages/web/styles.liquid
+++ b/data/messages/web/styles.liquid
@@ -97,6 +97,12 @@
         font-size: 16px;
         padding-left: var(--spacing);
         border-radius: var(--border-radius);
+        outline: none;
+    }
+
+    input[type=text]:focus {
+        border: solid 1px var(--color-primary);
+        outline: solid 2px var(--color-primary) !important;
     }
 
     .input-inline {
@@ -120,6 +126,20 @@
     .input-inline-button {
         width: 120px;
         border-radius: 0 var(--border-radius) var(--border-radius) 0 !important;
+    }
+
+    .input-radio-group {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin-bottom: 16px;
+    }
+
+    .input-radio-control {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 8px;
     }
 
     .form-error {

--- a/db/migrations/044_oauth_session_token_cache.rb
+++ b/db/migrations/044_oauth_session_token_cache.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:oauth_sessions) do
+      add_column :token_json, :jsonb
+      drop_column :authorization_code
+      add_constraint(
+        :no_token_json_if_used,
+        "NOT (used_at IS NOT NULL AND token_json IS NOT NULL)",
+      )
+    end
+  end
+
+  down do
+    alter_table(:oauth_sessions) do
+      drop_column :token_json
+      add_column :authorization_code, :text
+    end
+  end
+end

--- a/lib/webhookdb/apps.rb
+++ b/lib/webhookdb/apps.rb
@@ -65,7 +65,10 @@ module Webhookdb::Apps
       map "/terminal" do
         run Webhookdb::Apps::Webterm.to_app
       end
-      use Rack::SimpleRedirect, routes: REDIRECTS
+      use Rack::SimpleRedirect, routes: (REDIRECTS.each_with_object({}) do |(k, v), memo|
+        memo[k] = v
+        memo["#{k}/"] = v
+      end)
       run Webhookdb::Apps::API.build_app
     end
   end

--- a/lib/webhookdb/oauth.rb
+++ b/lib/webhookdb/oauth.rb
@@ -11,20 +11,12 @@ module Webhookdb::Oauth
     end
   end
 
-  # rubocop:disable Lint/UnusedMethodArgument
   class Provider
     # @return [String] Unique key to identify the provider.
     def key = raise NotImplementedError
 
     # @return [String] Name of the app to present to users.
     def app_name = raise NotImplementedError
-
-    # True if auth with this provider requires the user auth in WebhookDB,
-    # false if we can get their email from the Oauth process.
-    # If the access token can be used to get the 'me' user,
-    # we can usually use their email for the customer,
-    # but this may not be possible for some integrations.
-    def requires_webhookdb_auth? = raise NotImplementedError
 
     # This is similar to `supports_webhooks` in the Replicator descriptors,
     # except that this is used to make the success page dynamic.
@@ -39,23 +31,12 @@ module Webhookdb::Oauth
     # @return [Webhookdb::Oauth::Tokens]
     def exchange_authorization_code(code:) = raise NotImplementedError
 
-    # @param tokens [Webhookdb::Oauth::Tokens]
-    # @param scope [Hash] Used to store data needed in later calls, like when building integrations.
-    # @return [Array{TrueClass, FalseClass, Webhookdb::Customer}]
-    def find_or_create_customer(tokens:, scope:)
-      raise "should not be called" if self.requires_webhookdb_auth?
-      raise NotImplementedError
-    end
-
     # Create the actual service integrations for the given org.
     # @param organization [Webhookdb::Organization]
     # @param tokens [Webhookdb::Oauth::Tokens]
-    # @param scope [Hash]
     # @return [Webhookdb::ServiceIntegration]
-    def build_marketplace_integrations(organization:, tokens:, scope:) = raise NotImplementedError
-  end
-  # rubocop:enable Lint/UnusedMethodArgument
-
+    def build_marketplace_integrations(organization:, tokens:) = raise NotImplementedError
+end
   class << self
     def register(cls)
       key = cls.new.key

--- a/lib/webhookdb/oauth/fake_provider.rb
+++ b/lib/webhookdb/oauth/fake_provider.rb
@@ -5,10 +5,9 @@ require "webhookdb/increase"
 class Webhookdb::Oauth::FakeProvider < Webhookdb::Oauth::Provider
   class << self
     # If any of these are non-nil, they're called instead of the instance method.
-    attr_accessor :requires_webhookdb_auth, :supports_webhooks, :exchange_authorization_code
+    attr_accessor :supports_webhooks, :exchange_authorization_code
 
     def reset
-      self.requires_webhookdb_auth = nil
       self.supports_webhooks = nil
       self.exchange_authorization_code = nil
     end
@@ -16,7 +15,6 @@ class Webhookdb::Oauth::FakeProvider < Webhookdb::Oauth::Provider
 
   def key = "fake"
   def app_name = "Fake"
-  def requires_webhookdb_auth? = _call_or_do(:requires_webhookdb_auth) { true }
   def supports_webhooks? = _call_or_do(:supports_webhooks) { true }
 
   def authorization_url(state:)
@@ -27,10 +25,6 @@ class Webhookdb::Oauth::FakeProvider < Webhookdb::Oauth::Provider
     return _call_or_do(:exchange_authorization_code) do
       Webhookdb::Oauth::Tokens.new(access_token: "access-#{code}", refresh_token: "refresh-#{code}")
     end
-  end
-
-  def find_or_create_customer(tokens:, **)
-    return Webhookdb::Customer.find_or_create_for_email("#{tokens.access_token}@webhookdb.com")
   end
 
   def build_marketplace_integrations(organization:, tokens:, **)

--- a/lib/webhookdb/oauth/front_provider.rb
+++ b/lib/webhookdb/oauth/front_provider.rb
@@ -10,7 +10,6 @@ class Webhookdb::Oauth::FrontProvider < Webhookdb::Oauth::Provider
   def client_id = Webhookdb::Front.client_id
   def client_secret = Webhookdb::Front.client_secret
 
-  def requires_webhookdb_auth? = true
   def supports_webhooks? = true
 
   def authorization_url(state:)

--- a/lib/webhookdb/oauth/increase_provider.rb
+++ b/lib/webhookdb/oauth/increase_provider.rb
@@ -7,8 +7,6 @@ class Webhookdb::Oauth::IncreaseProvider < Webhookdb::Oauth::Provider
 
   def key = "increase"
   def app_name = "Increase"
-  # We cannot get the authed user from the Increase OAuth token
-  def requires_webhookdb_auth? = true
   # Increase POSTs all Oauth app webhooks to the same place
   def supports_webhooks? = true
 

--- a/lib/webhookdb/organization_membership.rb
+++ b/lib/webhookdb/organization_membership.rb
@@ -11,6 +11,10 @@ class Webhookdb::OrganizationMembership < Webhookdb::Postgres::Model(:organizati
   many_to_one :customer, class: "Webhookdb::Customer"
   many_to_one :membership_role, class: "Webhookdb::Role"
 
+  dataset_module do
+    def admin = self.where(membership_role: Webhookdb::Role.admin_role)
+  end
+
   def verified?
     return self.verified
   end

--- a/lib/webhookdb/service/view_api.rb
+++ b/lib/webhookdb/service/view_api.rb
@@ -23,7 +23,7 @@ module Webhookdb::Service::ViewApi
       |
         tmpl_file = File.open(Webhookdb::DATA_DIR + data_rel_path)
         liquid_tmpl = Liquid::Template.parse(tmpl_file.read)
-        rendered = liquid_tmpl.render!(vars.stringify_keys, registers: {})
+        rendered = liquid_tmpl.render!(vars.deep_stringify_keys, registers: {})
         _endpoint.content_type content_type
         if serialize_view_params
           _endpoint.cookies[:whdbviewparams] = {path: data_rel_path, vars:, content_type:}.to_json

--- a/spec/webhookdb/oauth/intercom_provider_spec.rb
+++ b/spec/webhookdb/oauth/intercom_provider_spec.rb
@@ -29,27 +29,6 @@ RSpec.describe Webhookdb::Oauth::IntercomProvider, :db do
     end
   end
 
-  describe "find_or_create_customer" do
-    let(:tokens) { Webhookdb::Oauth::Tokens.new(access_token: "intercom_auth_token", refresh_token: nil) }
-
-    let(:user_resp) { load_fixture_data("intercom/get_user") }
-
-    def stub_token_info_request
-      return stub_request(:get, "https://api.intercom.io/me").
-          to_return(json_response(user_resp))
-    end
-
-    it "finds or creates a user with the intercom email" do
-      req = stub_token_info_request
-      scope = {}
-      created, cust = provider.find_or_create_customer(tokens:, scope:)
-      expect(req).to have_been_made
-      expect(created).to be(true)
-      expect(cust).to have_attributes(email: "ginger@example.com")
-      expect(scope).to include(me_response: user_resp)
-    end
-  end
-
   describe "build_marketplace_integrations" do
     let(:tokens) { Webhookdb::Oauth::Tokens.new(access_token: "intercom_auth_token", refresh_token: nil) }
 
@@ -62,9 +41,12 @@ RSpec.describe Webhookdb::Oauth::IntercomProvider, :db do
     end
 
     it "builds integrations" do
-      scope = {me_response: load_fixture_data("intercom/get_user")}
-      root_sint = provider.build_marketplace_integrations(organization: org, tokens:, scope:)
+      req = stub_request(:get, "https://api.intercom.io/me").
+        to_return(json_response(load_fixture_data("intercom/get_user")))
+
+      root_sint = provider.build_marketplace_integrations(organization: org, tokens:)
       expect(root_sint).to have_attributes(organization: be === org, service_name: "intercom_marketplace_root_v1")
+      expect(req).to have_been_made
       expect(org.refresh.service_integrations).to contain_exactly(
         have_attributes(
           service_name: "intercom_marketplace_root_v1",

--- a/spec/webhookdb/oauth_spec.rb
+++ b/spec/webhookdb/oauth_spec.rb
@@ -13,26 +13,4 @@ RSpec.describe Webhookdb::Oauth, :db do
       expect(described_class.usable.all).to contain_exactly(be === usable)
     end
   end
-
-  describe "Provider" do
-    describe "#find_or_create_customer" do
-      it "errors if provider requires auth" do
-        cls = Class.new(described_class::Provider) do
-          def requires_webhookdb_auth? = true
-        end
-        expect do
-          cls.new.find_or_create_customer(tokens: nil, scope: nil)
-        end.to raise_error(RuntimeError, /not be called/)
-      end
-
-      it "raises NIE if provider does not require auth" do
-        cls = Class.new(described_class::Provider) do
-          def requires_webhookdb_auth? = false
-        end
-        expect do
-          cls.new.find_or_create_customer(tokens: nil, scope: nil)
-        end.to raise_error(NotImplementedError)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Overhaul OAuth flow

We were using `/me`-type endpoints to get the OAuth'ed users
email and other info. But we don't want to trust this,
since it requires the oauth provider verifies emails,
which is probably fine, but not something we can depend on.

Instead, always go through the auth flow when authorizing WebhookDB.

Add an 'org chooser' step when doing setup.
We were always creating the replicators in the
first default, admin org, but this is not suitable in
many cases. Someone should be able to create a new org
for their company (not their personal org)
and fill it with replicators, or use an existing org
(as I need to do for Increase).

Also polish up the UI, such as a title and favicon.

---

Redirects should always support trailing slash