### PR TITLE
Handle the intercom contact.delete event

### DIFF
--- a/lib/webhookdb/replicator/intercom_contact_v1.rb
+++ b/lib/webhookdb/replicator/intercom_contact_v1.rb
@@ -25,12 +25,44 @@ class Webhookdb::Replicator::IntercomContactV1 < Webhookdb::Replicator::Base
 
   def _denormalized_columns
     return [
-      Webhookdb::Replicator::Column.new(:external_id, TEXT),
-      Webhookdb::Replicator::Column.new(:email, TEXT),
-      Webhookdb::Replicator::Column.new(:created_at, TIMESTAMP, converter: QUESTIONABLE_TIMESTAMP),
-      Webhookdb::Replicator::Column.new(:updated_at, TIMESTAMP, converter: QUESTIONABLE_TIMESTAMP),
+      # All of these fields are missing on delete.
+      # We merge the deleted info into an existing one when handling the upsert.
+      Webhookdb::Replicator::Column.new(:external_id, TEXT, optional: true),
+      Webhookdb::Replicator::Column.new(:email, TEXT, optional: true),
+      Webhookdb::Replicator::Column.new(
+        :created_at, TIMESTAMP, converter: QUESTIONABLE_TIMESTAMP, optional: true,
+      ),
+      Webhookdb::Replicator::Column.new(
+        :updated_at, TIMESTAMP, converter: QUESTIONABLE_TIMESTAMP, optional: true,
+      ),
+      # This is set in the contact.deleted webhook
+      Webhookdb::Replicator::Column.new(:deleted_at, TIMESTAMP, optional: true),
     ]
   end
 
   def _mixin_backfill_url = "https://api.intercom.io/contacts"
+
+  def _resource_and_event(request)
+    resource, event = super
+    return resource, nil if event.nil?
+    if event.fetch("topic") == "contact.deleted"
+      resource["updated_at"] = Time.now
+      resource["deleted_at"] = Time.now
+    end
+    return resource, event
+  end
+
+  def _upsert_update_expr(inserting, enrichment: nil)
+    result = super
+    is_deleting = inserting[:deleted_at] && !inserting[:created_at]
+    if is_deleting
+      data_col = Sequel[self.service_integration.table_name.to_sym][:data]
+      result = {
+        deleted_at: result.fetch(:deleted_at),
+        updated_at: result.fetch(:updated_at),
+        data: Sequel.join([data_col, Sequel.lit('\'{"deleted":true}\'::jsonb')]),
+      }
+    end
+    return result
+  end
 end

--- a/lib/webhookdb/replicator/intercom_v1_mixin.rb
+++ b/lib/webhookdb/replicator/intercom_v1_mixin.rb
@@ -6,6 +6,7 @@ module Webhookdb::Replicator::IntercomV1Mixin
   # Handle both.
   QUESTIONABLE_TIMESTAMP = Webhookdb::Replicator::Column::IsomorphicProc.new(
     ruby: lambda do |i, **_|
+      return nil if i.nil?
       return Time.at(i)
     rescue TypeError
       return Time.parse(i)


### PR DESCRIPTION
We get sent a minimal contact.
Merge it into an existing row if there is one,
and avoid blowing away all the old information about the contact.