### PR TITLE
Intercom: Handle conversation.deleted events

### DIFF
--- a/lib/webhookdb/jobs/emailer.rb
+++ b/lib/webhookdb/jobs/emailer.rb
@@ -9,7 +9,6 @@ class Webhookdb::Jobs::Emailer
   splay 5.seconds
 
   def _perform
-    self.logger.info "Sending pending emails"
     Webhookdb::Message.send_unsent
   end
 end

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
@@ -22,7 +22,7 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
           self.with_log_tags(sint.log_tags) do
             splay = rand(1..max_splay)
             enqueued_job_id = Webhookdb::Jobs::IcalendarSync.perform_in(splay, sint.id, calendar_external_id)
-            self.logger.info("enqueued_icalendar_sync", calendar_external_id:, enqueued_job_id:)
+            self.logger.debug("enqueued_icalendar_sync", calendar_external_id:, enqueued_job_id:)
           end
         end
       end

--- a/lib/webhookdb/jobs/icalendar_sync.rb
+++ b/lib/webhookdb/jobs/icalendar_sync.rb
@@ -16,7 +16,7 @@ class Webhookdb::Jobs::IcalendarSync
         self.logger.warn("icalendar_sync_row_miss", calendar_external_id:)
         return
       end
-      self.logger.info("icalendar_sync_start")
+      self.logger.debug("icalendar_sync_start")
       sint.replicator.sync_row(row)
     end
   end

--- a/lib/webhookdb/replicator/intercom_contact_v1.rb
+++ b/lib/webhookdb/replicator/intercom_contact_v1.rb
@@ -27,13 +27,13 @@ class Webhookdb::Replicator::IntercomContactV1 < Webhookdb::Replicator::Base
     return [
       # All of these fields are missing on delete.
       # We merge the deleted info into an existing one when handling the upsert.
-      Webhookdb::Replicator::Column.new(:external_id, TEXT, optional: true),
-      Webhookdb::Replicator::Column.new(:email, TEXT, optional: true),
+      Webhookdb::Replicator::Column.new(:external_id, TEXT, optional: true, index: true),
+      Webhookdb::Replicator::Column.new(:email, TEXT, optional: true, index: true),
       Webhookdb::Replicator::Column.new(
-        :created_at, TIMESTAMP, converter: QUESTIONABLE_TIMESTAMP, optional: true,
+        :created_at, TIMESTAMP, converter: QUESTIONABLE_TIMESTAMP, optional: true, index: true,
       ),
       Webhookdb::Replicator::Column.new(
-        :updated_at, TIMESTAMP, converter: QUESTIONABLE_TIMESTAMP, optional: true,
+        :updated_at, TIMESTAMP, converter: QUESTIONABLE_TIMESTAMP, optional: true, index: true,
       ),
       # This is set in the contact.deleted webhook
       Webhookdb::Replicator::Column.new(:deleted_at, TIMESTAMP, optional: true),

--- a/lib/webhookdb/replicator/oauth_refresh_access_token_mixin.rb
+++ b/lib/webhookdb/replicator/oauth_refresh_access_token_mixin.rb
@@ -29,7 +29,7 @@ module Webhookdb::Replicator::OAuthRefreshAccessTokenMixin
       if got
         yield got
       else
-        self.logger.info "creating_access_token"
+        self.logger.debug "creating_access_token", access_token_cache_key: key
         form_body = URI.encode_www_form(
           {
             client_id: self.service_integration.backfill_key,

--- a/lib/webhookdb/sentry.rb
+++ b/lib/webhookdb/sentry.rb
@@ -12,6 +12,7 @@ module Webhookdb::Sentry
 
   configurable(:sentry) do
     setting :dsn, ""
+    setting :log_level, :warn
 
     # Apply the current configuration to Sentry.
     # See https://docs.sentry.io/clients/ruby/config/ for more info.
@@ -22,6 +23,7 @@ module Webhookdb::Sentry
         Sentry.init do |config|
           config.dsn = dsn
           config.logger = self.logger
+          config.logger.level = self.log_level
         end
       else
         Sentry.instance_variable_set(:@main_hub, nil)


### PR DESCRIPTION
Just like contact.archived and deleted,
we have slim events to handle.

Also add indices to created_at and updated_at fields on contacts and conversations.
