### PR TITLE
Icalendar: Delete stale cancelled events

### DIFF
--- a/lib/webhookdb/icalendar.rb
+++ b/lib/webhookdb/icalendar.rb
@@ -19,5 +19,8 @@ module Webhookdb::Icalendar
     # or two threads for 7 hours. The resyncs are spread out across the sync period
     # (ie, no thundering herd every 8 hours), but it is still a good idea to sync as infrequently as possible.
     setting :sync_period_hours, 6
+
+    # Cancelled events that were cancelled this long ago are deleted from the database.
+    setting :stale_cancelled_event_threshold_days, 35
   end
 end

--- a/lib/webhookdb/jobs/icalendar_delete_stale_cancelled_events.rb
+++ b/lib/webhookdb/jobs/icalendar_delete_stale_cancelled_events.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "webhookdb/async/scheduled_job"
+require "webhookdb/jobs"
+
+class Webhookdb::Jobs::IcalendarDeleteStaleCancelledEvents
+  extend Webhookdb::Async::ScheduledJob
+
+  cron "37 7 * * *" # Once a day
+  splay 120
+
+  def _perform
+    Webhookdb::ServiceIntegration.where(service_name: "icalendar_event_v1").each do |sint|
+      self.with_log_tags(sint.log_tags) do
+        sint.replicator.delete_stale_cancelled_events
+      end
+    end
+  end
+end


### PR DESCRIPTION
Each night, go through all icalendar_event_v1 replicators and delete CANCELLED events between 35 and 45 days old.

This avoids stacking up cancelled events due to changing UIDs, as detailed in https://github.com/webhookdb/webhookdb/issues/890

Also fixes some inconsistencies with row update timestamps (it's now captured when the feed replication starts, and is used everywhere, rather than using Time.now in many places).

Fixes #890.

I decided against handling deadlocks explicitly,
since the Sidekiq retry will be sufficient,
unless this becomes endemic, which would indicate
something bad and unexpected is happening.

Note that we were able to fix this using existing columns and indices, so this does not require a schema change (with the caveat about age ranges below).

The row_updated_search uses a bounded older range
to avoid a scan over all old events,
since a full scan shouldn't be needed
as long as this runs regularly.

However, you may wish to run this as a one-time thing after deploying this code to clean up all old events:

```rb
Webhookdb::ServiceIntegration.where(service_name: "icalendar_event_v1").each do |sint|
  sint.replicator.delete_stale_cancelled_events
end
```
