### PR TITLE
Front-signalwire: Handle null SW body

### DIFF
--- a/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
+++ b/lib/webhookdb/replicator/front_signalwire_message_channel_app_v1.rb
@@ -324,7 +324,7 @@ All of this information can be found in the WebhookDB docs, at https://docs.webh
     def _sync_front_inbound(sender:, texted_at:, item:, body:)
       body = {
         sender: {handle: sender},
-        body:,
+        body: body || "<no body>",
         delivered_at: texted_at.to_i,
         metadata: {
           external_id: item.fetch(:external_id),


### PR DESCRIPTION
For some unknown reason, signalwire message bodies can be `null`. If that's the case,
Front errors since `body.body` must be a string.

Use the value `'<no body>'` if the signalwire message body is null. If it's empty string, we'll still use it as-is, but I figure it's better to call out the null body in case it represents something unexpected on the SW side.
