### PR TITLE
Fixes: Ical rules, strip whitespace, developer alerts

### DIFF
--- a/lib/webhookdb/api/entities.rb
+++ b/lib/webhookdb/api/entities.rb
@@ -47,11 +47,13 @@ module Webhookdb::API
     expose :verified_memberships, with: OrganizationMembershipEntity
     expose :verified_memberships_formatted do |instance|
       lines = instance.verified_memberships.map { |m| "#{m.organization.display_string}: #{m.status}" }
+      lines.sort!
       lines.join("\n")
     end
     expose :invited_memberships, as: :invitations, with: OrganizationMembershipEntity
     expose :invitations_formatted do |instance|
       lines = instance.invited_memberships.map { |m| "#{m.organization.display_string}: #{m.invitation_code}" }
+      lines.sort!
       lines.join("\n")
     end
     expose :display_headers do |_|

--- a/lib/webhookdb/replicator/base.rb
+++ b/lib/webhookdb/replicator/base.rb
@@ -159,6 +159,7 @@ class Webhookdb::Replicator::Base
   def process_state_change(field, value, attr: nil)
     attr ||= field
     desc = self.descriptor
+    value = value.strip if value.respond_to?(:strip)
     case field
       when *self._webhook_state_change_fields
         # If we don't support webhooks, then the backfill state machine may be using it.

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -487,6 +487,7 @@ The secret to use for signing is:
         ical = ical.gsub(/BYMONTHDAY=[\d,]+/, "")
         ical.delete_prefix! ";"
         ical.delete_suffix! ";"
+        ical.squeeze!(";")
       end
       return IceCube::IcalParser.rule_from_ical(ical)
     end

--- a/spec/webhookdb/api/me_spec.rb
+++ b/spec/webhookdb/api/me_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Webhookdb::API::Me, :db do
       expect(lines).to contain_exactly(
         ["Default Org", "Hi (hi)"],
         ["Email", "a@b.co"],
-        ["Memberships", "Hi (hi): member\nBye (bye): admin"],
+        ["Memberships", "Bye (bye): admin\nHi (hi): member"],
         ["Invitations", "Bar (bar): code1\nFoo (foo): code2"],
       )
     end

--- a/spec/webhookdb/organization/alerting_spec.rb
+++ b/spec/webhookdb/organization/alerting_spec.rb
@@ -72,7 +72,13 @@ RSpec.describe Webhookdb::Organization::Alerting, :db do
           alerting.dispatch_alert(tmpl)
         end
       end
+      # Sent 20 emails to each admin
       expect(Webhookdb::Message::Delivery.all).to have_length(40)
+      # Move to tomorrow and assert we send emails
+      Timecop.travel(25.hours.from_now) do
+        alerting.dispatch_alert(tmpl)
+      end
+      expect(Webhookdb::Message::Delivery.all).to have_length(42)
     end
   end
 end

--- a/spec/webhookdb/replicator/fake_spec.rb
+++ b/spec/webhookdb/replicator/fake_spec.rb
@@ -613,6 +613,13 @@ or leave blank to choose the first option.
         end.to raise_error(ArgumentError)
       end
 
+      it "always strips whitespace from the value" do
+        sint = Webhookdb::Fixtures.service_integration.create
+        sint.replicator.process_state_change("backfill_secret", " ab cd ")
+        sint.replicator.process_state_change("webhook_secret", "\nxy zw\n")
+        expect(sint).to have_attributes(backfill_secret: "ab cd", webhook_secret: "xy zw")
+      end
+
       describe "setting dependency_choice" do
         let(:org) { Webhookdb::Fixtures.organization.create }
         let(:fac) { Webhookdb::Fixtures.service_integration(organization: org) }

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -1331,7 +1331,7 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
         DTEND;VALUE=DATE:20230907
         DTSTAMP:20230819T112238Z
         DTSTART;VALUE=DATE:20230906
-        RRULE:FREQ=WEEKLY;UNTIL=20231001;INTERVAL=2;BYMONTHDAY=4,26,5
+        RRULE:FREQ=WEEKLY;UNTIL=20231001;BYMONTHDAY=4,26,5;INTERVAL=2
         SEQUENCE:0
         X-Comment:Same as above but with multiple BYMONTHDAY
         SUMMARY:Circles


### PR DESCRIPTION
Fix missing alerts

Admins stopped getting alerts after a certain point,
because we weren't filtering 'sent alerts' to just the last day.

Fixes https://github.com/webhookdb/webhookdb/issues/896

---

Service integration fields strip whitespace

Remove trailing and leading whitespace from all
fields in `process_state_change`.
Cannot believe this has been around so long.

Fixes https://github.com/webhookdb/webhookdb/issues/895

---

Better handle ambiguous icalendar rules

Our fix for `FREQ=WEEKLY` and `BYMONTHDAY` could result in
`';;'` appearing in the rrule, which is invalid.
This squashes such a case and ensures the rule is well-formed.
