### PR TITLE
Add `url_recorder_v1` replicator

### DIFF
--- a/data/messages/replicators/url-recorder.liquid
+++ b/data/messages/replicators/url-recorder.liquid
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Thanks! - WebhookDB</title>
+    {% include 'web/partials/head' %}
+</head>
+<body>
+<div class="layout">
+    <div class="flex column align-items-center content">
+        <div class="text-center mt-2">
+            {{ content }}
+        </div>
+        <div class="text-center mt-2 flex column align-items-middle w-100">
+            <hr class="w-100"/>
+            <span class="mt-2 text-small">Hosted at <a href="https://webhookdb.com">https://webhookdb.com</a></span>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/data/messages/web/styles.liquid
+++ b/data/messages/web/styles.liquid
@@ -48,6 +48,10 @@
         text-align: center;
     }
 
+    .text-small {
+        font-size: 80%;
+    }
+
     .btn {
         background-color: var(--color-primary);
         border: none;

--- a/lib/webhookdb/api/helpers.rb
+++ b/lib/webhookdb/api/helpers.rb
@@ -205,6 +205,7 @@ module Webhookdb::API::Helpers
             path: process_kwargs[:request_path],
             headers: process_kwargs[:headers],
             body: process_kwargs[:body],
+            rack_request: request,
           )
           inserted = svc.upsert_webhook(whreq)
           s_body = svc.synchronous_processing_response_body(upserted: inserted, request: whreq)

--- a/lib/webhookdb/api/service_integrations.rb
+++ b/lib/webhookdb/api/service_integrations.rb
@@ -16,7 +16,7 @@ class Webhookdb::API::ServiceIntegrations < Webhookdb::API::V1
   # because external services (so no auth) will be posting webhooks here.
   # Depend on webhook verification to ensure the request is valid.
   resource :service_integrations do
-    route [:post, :put, :delete, :patch], "/:opaque_id*" do
+    route [:get, :post, :put, :delete, :patch], "/:opaque_id*" do
       opaque_id = params[:opaque_id]
       handle_webhook_request(opaque_id) do
         Webhookdb::ServiceIntegration[opaque_id:] or merror!(400, "No integration with that id")
@@ -95,7 +95,7 @@ If the list does not look correct, you can contact support at #{Webhookdb.suppor
                 :guard_confirm,
                 "WARNING: #{org.name} already has an integration for service #{params[:service_name]}.\n" \
                 "Press Enter to create another, or Ctrl+C to quit.\n" \
-                "Modify the existing integration using `webhookdb integrations #{existing.opaque_id} setup`",
+                "Modify the existing integration using `webhookdb integrations setup #{existing.opaque_id}`",
               )
             end
           end

--- a/lib/webhookdb/replicator/fake.rb
+++ b/lib/webhookdb/replicator/fake.rb
@@ -109,9 +109,8 @@ class Webhookdb::Replicator::Fake < Webhookdb::Replicator::Base
   end
 
   def _resource_and_event(request)
-    body = request.body
-    return self.class.resource_and_event_hook.call(body) if self.class.resource_and_event_hook
-    return body, nil
+    return self.class.resource_and_event_hook.call(request) if self.class.resource_and_event_hook
+    return request.body, nil
   end
 
   def _update_where_expr

--- a/lib/webhookdb/replicator/url_recorder_v1.rb
+++ b/lib/webhookdb/replicator/url_recorder_v1.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+class Webhookdb::Replicator::UrlRecorderV1 < Webhookdb::Replicator::Base
+  include Appydays::Loggable
+
+  # @return [Webhookdb::Replicator::Descriptor]
+  def self.descriptor
+    return Webhookdb::Replicator::Descriptor.new(
+      name: "url_recorder_v1",
+      ctor: ->(sint) { self.new(sint) },
+      feature_roles: [],
+      resource_name_singular: "URL Recorder",
+      supports_webhooks: true,
+      supports_backfill: false,
+      description: "Record any visit to the webhook URL for later inspection. " \
+                   "Useful for recording scans, like visiting QR Code. After the webhook, " \
+                   "visitors can be redirected, or shown a Markdown page.",
+    )
+  end
+
+  def _remote_key_column = Webhookdb::Replicator::Column.new(:unique_id, BIGINT)
+
+  def requires_sequence? = true
+
+  def _denormalized_columns
+    col = Webhookdb::Replicator::Column
+    return [
+      col.new(:inserted_at, TIMESTAMP, index: true),
+      col.new(:request_method, TEXT),
+      col.new(:path, TEXT),
+      col.new(:full_url, TEXT),
+      col.new(:user_agent, TEXT),
+      col.new(:ip, TEXT),
+      col.new(:content_type, TEXT),
+      col.new(:parsed_query, OBJECT),
+      col.new(:parsed_body, OBJECT),
+      col.new(:raw_body, TEXT),
+    ]
+  end
+
+  def _timestamp_column_name = :inserted_at
+  def _resource_and_event(_request) = [{}, nil]
+
+  def _update_where_expr = self.qualified_table_sequel_identifier[:inserted_at] < Sequel[:excluded][:inserted_at]
+
+  def _prepare_for_insert(_resource, event, request, enrichment)
+    # rr = Rack::Request.new
+    rr = request.rack_request
+    raise Webhookdb::InvalidPrecondition, "#{request} must have rack_request set" if rr.nil?
+    r = {
+      "unique_id" => self.service_integration.sequence_nextval,
+      "inserted_at" => Time.now,
+      "request_method" => rr.request_method,
+      "path" => rr.path,
+      "parsed_query" => rr.GET,
+      "raw_query" => rr.query_string,
+      "full_url" => rr.url,
+      "user_agent" => rr.user_agent,
+      "ip" => rr.ip,
+      "content_type" => rr.content_type,
+      "raw_body" => nil,
+      "parsed_body" => nil,
+    }
+    if !request.body.is_a?(String)
+      # If we were able to parse the request body (usually means it's JSON), store it.
+      r["parsed_body"] = request.body
+    elsif rr.POST.present?
+      # If Rack was able to parse the request body (usually means it's form encoded), store it.
+      r["parsed_body"] = rr.POST
+    else
+      # Store the raw body if nothing can parse it.
+      r["raw_body"] = request.body
+    end
+    return super(r, event, request, enrichment)
+  end
+
+  def _resource_to_data(*) = {}
+
+  def _webhook_response(_request) = self.redirect? ? self._redirect_response : self._page_response
+
+  def process_webhooks_synchronously? = true
+
+  def synchronous_processing_response_body(*)
+    resp = self.redirect? ? self._redirect_response : self._page_response
+    return resp.body
+  end
+
+  def redirect? = self.service_integration.api_url =~ %r{^https?://}
+
+  def _redirect_response
+    headers = {"Location" => self.service_integration.api_url, "Content-Type" => "text/plain"}
+    return Webhookdb::WebhookResponse.new(status: 302, headers:, body: "")
+  end
+
+  def _page_response
+    headers = {"Content-Type" => "text/html; charset=UTF-8"}
+    content = self.service_integration.api_url
+    content_is_doc = content.start_with?("<!DOCTYPE") || content.starts_with?("<html")
+    body = if content_is_doc
+             content
+    else
+      tmpl_file = File.open(Webhookdb::DATA_DIR + "messages/replicators/url-recorder.liquid")
+      liquid_tmpl = Liquid::Template.parse(tmpl_file.read)
+      liquid_tmpl.render!({"content" => content})
+    end
+    return Webhookdb::WebhookResponse.new(status: 200, headers:, body:)
+  end
+
+  def calculate_webhook_state_machine
+    step = Webhookdb::Replicator::StateMachineStep.new
+    if self.service_integration.api_url.blank?
+      step.output = %(After users visit the WebhookDB endpoint,
+they can either be redirected to a location of your own,
+or we'll render an HTML page to show them.
+
+To use a redirect, input a URL starting with 'https://'.
+
+To render a page, paste in the HTML:
+
+- If the text starts with an `html` tag, it will be used as-is
+  for the page's HTML, so you can use your own styles.
+- Otherwise we assume the content is a relatively simple message,
+  and it's rendered with basic WebhookDB styles.)
+      return step.prompting("URL, HTML, or text").api_url(self.service_integration)
+    end
+    step.output = %(
+All set! Every visit to
+  #{self.webhook_endpoint}
+will be recorded.
+
+If you want to modify what users see after the visit is recorded,
+run `webhookdb integration reset #{self.descriptor.name}.
+
+#{self._query_help_output})
+    return step.completed
+  end
+end

--- a/lib/webhookdb/replicator/webhook_request.rb
+++ b/lib/webhookdb/replicator/webhook_request.rb
@@ -2,4 +2,8 @@
 
 class Webhookdb::Replicator::WebhookRequest < Webhookdb::TypedStruct
   attr_accessor :body, :headers, :path, :method
+  # @!attribute rack_request
+  # When a webhook is processed synchronously, this will be set to the Rack::Request.
+  # Normal (async) webhook processing does not have this available.
+  attr_accessor :rack_request
 end

--- a/lib/webhookdb/spec_helpers/whdb.rb
+++ b/lib/webhookdb/spec_helpers/whdb.rb
@@ -104,13 +104,14 @@ module Webhookdb::SpecHelpers::Whdb
     this.let(:request_method) { nil }
     this.let(:request_body) { nil }
     this.let(:request_headers) { nil }
+    this.let(:rack_request) { nil }
     this.let(:webhook_request) do
       Webhookdb::Replicator::WebhookRequest.new(
-        body: request_body, method: request_method, path: request_path, headers: request_headers,
+        body: request_body, method: request_method, path: request_path, headers: request_headers, rack_request:,
       )
     end
     this.define_method(:upsert_webhook) do |svc, **kw|
-      params = {body: request_body, headers: request_headers, method: request_method, path: request_path}
+      params = {body: request_body, headers: request_headers, method: request_method, path: request_path, rack_request:}
       params.merge!(**kw)
       svc.upsert_webhook(Webhookdb::Replicator::WebhookRequest.new(**params))
     end

--- a/spec/webhookdb/backfiller_spec.rb
+++ b/spec/webhookdb/backfiller_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Webhookdb::Backfiller, :db do
 
     it "ignores items that are not upserted by the replicator" do
       Webhookdb::Replicator::Fake.resource_and_event_hook = lambda { |r|
-        r.fetch("my_id") == "3" ? [nil, nil] : [r, nil]
+        r.body.fetch("my_id") == "3" ? [nil, nil] : [r.body, nil]
       }
       bf = backfiller_cls.new(
         sint,

--- a/spec/webhookdb/replicator/url_recorder_v1_spec.rb
+++ b/spec/webhookdb/replicator/url_recorder_v1_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "support/shared_examples_for_replicators"
+
+RSpec.describe Webhookdb::Replicator::UrlRecorderV1, :db do
+  it_behaves_like "a replicator", "url_recorder_v1" do
+    let(:request_path) { "/foo" }
+    let(:request_method) { "GET" }
+    let(:request_headers) { {"Accept" => "*"} }
+    let(:rack_request) do
+      Rack::Request.new(
+        {
+          "PATH_INFO" => "/mypath",
+          "QUERY_STRING" => "z=2",
+          "rack.url_scheme" => "http",
+          "REMOTE_ADDR" => "1.2.9.8",
+          "REMOTE_HOST" => "localhost",
+          "REQUEST_METHOD" => "GET",
+          "SCRIPT_NAME" => "/scriptname",
+          "SERVER_NAME" => "localhost",
+          "SERVER_PORT" => "9292",
+          "HTTP_USER_AGENT" => "Mozilla/5.0",
+          "REQUEST_PATH" => "/reqpath",
+        },
+      )
+    end
+
+    let(:body) { {"x" => 1} }
+    let(:supports_row_diff) { false }
+    let(:expected_row) do
+      include(
+        unique_id: 1,
+        data: be_empty,
+        request_method: "GET",
+        path: "/scriptname/mypath",
+        full_url: "http://localhost:9292/scriptname/mypath?z=2",
+        user_agent: "Mozilla/5.0",
+        ip: "1.2.9.8",
+        parsed_query: eq({"z" => "2"}),
+        parsed_body: eq({"x" => 1}),
+        raw_body: nil,
+      )
+    end
+
+    it "handles a string body" do
+      svc.create_table
+      rack_request.set_header("rack.input", Webhookdb::SpecHelpers::Service::Rewindable.new(""))
+      upsert_webhook(svc, body: "unparseable")
+      expect(svc.readonly_dataset(&:all)).to contain_exactly(
+        include(parsed_body: nil, raw_body: "unparseable"),
+      )
+    end
+
+    it "uses the form body if available" do
+      svc.create_table
+      rr = rack_request
+      rr.set_header("rack.input", Webhookdb::SpecHelpers::Service::Rewindable.new("x=y"))
+      rr.set_header("CONTENT_TYPE", "application/x-www-form-urlencoded")
+      upsert_webhook(svc, body: "x=1")
+      expect(svc.readonly_dataset(&:all)).to contain_exactly(
+        include(parsed_body: {"x" => "y"}, raw_body: nil),
+      )
+    end
+  end
+
+  # describe "webhook_response" do
+  #   let(:sint) { Webhookdb::Fixtures.service_integration.create(service_name: described_class.descriptor.name) }
+  #   let(:svc) { Webhookdb::Replicator.create(sint) }
+  #
+  #   it "returns a redirect if the api url starts with http" do
+  #     sint.update(api_url: "http://foo.bar")
+  #     req = fake_request
+  #     expect(svc.webhook_response(req)).to have_attributes(
+  #       status: 302,
+  #       body: "",
+  #       headers: include("Location" => "http://foo.bar"),
+  #     )
+  #   end
+  #
+  #   it "returns a redirect if the api url starts with https" do
+  #     sint.update(api_url: "https://foo.bar")
+  #     req = fake_request
+  #     expect(svc.webhook_response(req)).to have_attributes(
+  #       status: 302,
+  #       body: "",
+  #       headers: include("Location" => "https://foo.bar"),
+  #     )
+  #   end
+  #
+  #   it "uses the given html if the api_url starts with a doctype" do
+  #     sint.update(api_url: "<!DOCTYPE html>\n<html lang='en-us'><body>hi</body></html>")
+  #     req = fake_request
+  #     expect(svc.webhook_response(req)).to have_attributes(
+  #       status: 200,
+  #       body: sint.api_url,
+  #       headers: include("Content-Type" => "text/html"),
+  #     )
+  #   end
+  #
+  #   it "uses the given html if the api_url starts with an html element" do
+  #     sint.update(api_url: "<html lang='en-us'><body>hi</body></html>")
+  #     req = fake_request
+  #     expect(svc.webhook_response(req)).to have_attributes(
+  #       status: 200,
+  #       body: sint.api_url,
+  #       headers: include("Content-Type" => "text/html"),
+  #     )
+  #   end
+  #
+  #   it "renders the api_url in an HTML template otherwise" do
+  #     sint.update(api_url: "<p>thanks!</p>")
+  #     req = fake_request
+  #     expect(svc.webhook_response(req)).to have_attributes(
+  #       status: 200,
+  #       body: include('<div class="layout">').and(include("<p>thanks!</p>")),
+  #       headers: include("Content-Type" => "text/html"),
+  #     )
+  #   end
+  # end
+  #
+  # describe "state machine calculation" do
+  #   let(:sint) do
+  #     Webhookdb::Fixtures.service_integration.create(service_name: described_class.descriptor.name, api_url: "")
+  #   end
+  #   let(:svc) { Webhookdb::Replicator.create(sint) }
+  #
+  #   describe "calculate_webhook_state_machine" do
+  #     it "asks for the api url" do
+  #       sm = svc.calculate_webhook_state_machine
+  #       expect(sm).to have_attributes(
+  #         needs_input: true,
+  #         prompt: "Paste or type your URL, HTML, or text here:",
+  #         prompt_is_secret: false,
+  #         post_to_url: end_with("/transition/api_url"),
+  #         complete: false,
+  #         output: match("they can either be redirected"),
+  #       )
+  #     end
+  #
+  #     it "confirms reciept of api url, returns org database info" do
+  #       sint.api_url = "hello"
+  #       sm = svc.calculate_webhook_state_machine
+  #       expect(sm).to have_attributes(
+  #         needs_input: false,
+  #         complete: true,
+  #         output: match(/Every visit to/),
+  #       )
+  #     end
+  #   end
+  # end
+end


### PR DESCRIPTION
Add `url_recorder_v1` replicator

For making things like QR code trackers
which can be recorded into a database.

---

Support GET, add Rack Req for sync processing

When processing webhooks synchronously,
we now pass in the `Rack::Request` making the actual request.
This is a new attribute, `Webhookdb::WebhookRequest#rack_request`.

This allows replicators access to the live request,
in case they need to store information like an IP
or request query params.

In theory we could store more of the env/request on `LoggedWebhook`,
but I'm hesitant to add more information there.
Though perhaps it should at least include the query string,
but that can be added when it's needed,
such as if an async replicator needs access to more request info.
