### PR TITLE
Trim whitespace from API inputs

### DIFF
--- a/lib/webhookdb/api/auth.rb
+++ b/lib/webhookdb/api/auth.rb
@@ -26,13 +26,12 @@ class Webhookdb::API::Auth < Webhookdb::API::V1
 
     params do
       optional :email,
-               type: String,
-               coerce_with: NormalizedEmail,
+               type: NormalizedEmail,
                prompt: {
                  message: "Welcome to WebhookDB!\nPlease enter your email:",
                  demo_mode_proc: ->(r) { r.params[:email] = "demo@webhookdb.com" },
                }
-      optional :token, type: String
+      optional :token, type: TrimmedString
     end
     post do
       message = ""
@@ -86,9 +85,9 @@ class Webhookdb::API::Auth < Webhookdb::API::V1
     end
 
     params do
-      requires :form_name, type: String
-      optional :email, type: String
-      optional :name, type: String
+      requires :form_name, type: TrimmedString
+      optional :email, type: TrimmedString
+      optional :name, type: TrimmedString
       optional :message, type: String
     end
     post :contact do

--- a/lib/webhookdb/api/db.rb
+++ b/lib/webhookdb/api/db.rb
@@ -6,15 +6,17 @@ require "webhookdb/api"
 require "webhookdb/replicator"
 
 class Webhookdb::API::Db < Webhookdb::API::V1
+  include Webhookdb::Service::Types
+
   helpers do
     params :fdw do
       optional :message_fdw, type: Boolean
       optional :message_views, type: Boolean
       optional :message_all, type: Boolean
-      requires :remote_server_name, type: String
-      requires :fetch_size, type: String
-      requires :local_schema, type: String
-      requires :view_schema, type: String
+      requires :remote_server_name, type: TrimmedString
+      requires :fetch_size, type: TrimmedString
+      requires :local_schema, type: TrimmedString
+      requires :view_schema, type: TrimmedString
     end
 
     def run_fdw
@@ -43,9 +45,9 @@ class Webhookdb::API::Db < Webhookdb::API::V1
         headers Webhookdb::API::ConnstrAuth.headers_desc
       end
       params do
-        requires :org_identifier, type: String
+        requires :org_identifier, type: TrimmedString
         optional :query, type: String, desc: "SQL to run."
-        optional :query_base64, type: String, desc: "Base64 encoded SQL. Mostly used for GET requests."
+        optional :query_base64, type: TrimmedString, desc: "Base64 encoded SQL. Mostly used for GET requests."
         exactly_one_of :query, :query_base64
       end
       send(httpmethod, :run_sql) do
@@ -87,7 +89,7 @@ class Webhookdb::API::Db < Webhookdb::API::V1
 
       desc "Enqueues a database migration."
       params do
-        optional :admin_url, type: String, prompt: {
+        optional :admin_url, type: TrimmedString, prompt: {
           message: "ADMIN Postgres connection URL, in the form 'postgres://user:password@host:port/dbname',\n" \
                    "that is capable of administrative operations on your database,\n" \
                    "such as creating and dropping schemas and tables.\n" \
@@ -96,7 +98,7 @@ class Webhookdb::API::Db < Webhookdb::API::V1
           disable: ->(_) { !Webhookdb::Organization::DbBuilder.allow_public_migrations },
         }
 
-        optional :readonly_url, type: String, prompt: {
+        optional :readonly_url, type: TrimmedString, prompt: {
           message: "READONLY Postgres connection URL.\n" \
                    "This string is displayed when you ask for your organization's connection information.\n" \
                    "If you are okay with this being your ADMIN URL, leave it blank.\n" \

--- a/lib/webhookdb/api/organizations.rb
+++ b/lib/webhookdb/api/organizations.rb
@@ -62,11 +62,11 @@ class Webhookdb::API::Organizations < Webhookdb::API::V1
 
       desc "Generates an invitation code for a user, adds pending membership in the organization."
       params do
-        optional :email, type: String, coerce_with: NormalizedEmail,
+        optional :email, type: NormalizedEmail,
                          prompt: "Enter the email to send the invitation to:"
         optional :role_name,
-                 type: String,
-                 values: Webhookdb::OrganizationMembership::VALID_ROLE_NAMES,
+                 type: TrimmedString,
+                 values: TrimmedString.map(Webhookdb::OrganizationMembership::VALID_ROLE_NAMES),
                  default: "member"
       end
       post :invite do
@@ -102,7 +102,7 @@ class Webhookdb::API::Organizations < Webhookdb::API::V1
 
       desc "Allows organization admin to remove customer from an organization"
       params do
-        optional :email, type: String, coerce_with: NormalizedEmail,
+        optional :email, type: NormalizedEmail,
                          prompt: "Enter the email of the member you are removing permissions from:"
         optional :guard_confirm
       end
@@ -149,9 +149,11 @@ class Webhookdb::API::Organizations < Webhookdb::API::V1
       params do
         optional :emails, type: [String], coerce_with: CommaSepArray,
                           prompt: "Enter the emails to modify the roles of as a comma-separated list:"
-        optional :role_name, type: String, values: Webhookdb::OrganizationMembership::VALID_ROLE_NAMES,
-                             prompt: "Enter the name of the role to assign " \
-                                     "(#{Webhookdb::OrganizationMembership::VALID_ROLE_NAMES.join(', ')}): "
+        optional :role_name,
+                 type: TrimmedString,
+                 values: TrimmedString.map(Webhookdb::OrganizationMembership::VALID_ROLE_NAMES),
+                 prompt: "Enter the name of the role to assign " \
+                         "(#{Webhookdb::OrganizationMembership::VALID_ROLE_NAMES.join(', ')}): "
         optional :guard_confirm
       end
       post :change_roles do
@@ -173,7 +175,7 @@ class Webhookdb::API::Organizations < Webhookdb::API::V1
 
       desc "Allow organization admin to change the name of the organization"
       params do
-        optional :name, type: String, prompt: "Enter the new organization name:"
+        optional :name, type: TrimmedString, prompt: "Enter the new organization name:"
       end
       post :rename do
         customer = current_customer
@@ -214,7 +216,7 @@ class Webhookdb::API::Organizations < Webhookdb::API::V1
 
     desc "Creates a new organization and adds current customer as a member."
     params do
-      optional :name, type: String, prompt: "Enter the name of the organization:"
+      optional :name, type: TrimmedString, prompt: "Enter the name of the organization:"
     end
     post :create do
       customer = current_customer
@@ -234,7 +236,7 @@ class Webhookdb::API::Organizations < Webhookdb::API::V1
 
     desc "Allows user to verify membership in an organization with an invitation code."
     params do
-      optional :invitation_code, type: String, prompt: "Enter the invitation code:"
+      optional :invitation_code, type: TrimmedString, prompt: "Enter the invitation code:"
     end
     post :join do
       customer = current_customer

--- a/lib/webhookdb/api/saved_queries.rb
+++ b/lib/webhookdb/api/saved_queries.rb
@@ -4,6 +4,8 @@ require "webhookdb/api"
 require "webhookdb/saved_query"
 
 class Webhookdb::API::SavedQueries < Webhookdb::API::V1
+  include Webhookdb::Service::Types
+
   resource :organizations do
     route_param :org_identifier do
       resource :saved_queries do
@@ -99,8 +101,10 @@ class Webhookdb::API::SavedQueries < Webhookdb::API::V1
 
           desc "Updates the field on a custom query."
           params do
-            optional :field, type: String, prompt: "What field would you like to update (one of: " \
-                                                   "#{Webhookdb::SavedQuery::CLI_EDITABLE_FIELDS.join(', ')}): "
+            optional :field,
+                     type: TrimmedString,
+                     prompt: "What field would you like to update (one of: " \
+                             "#{Webhookdb::SavedQuery::CLI_EDITABLE_FIELDS.join(', ')}): "
             optional :value, type: String, prompt: "What is the new value? "
           end
           post :update do
@@ -147,7 +151,9 @@ class Webhookdb::API::SavedQueries < Webhookdb::API::V1
           end
 
           params do
-            optional :field, type: String, values: Webhookdb::SavedQuery::INFO_FIELDS.keys + [""]
+            optional :field,
+                     type: TrimmedString,
+                     values: TrimmedString.map(Webhookdb::SavedQuery::INFO_FIELDS.keys + [""])
           end
           post :info do
             cq = lookup!

--- a/lib/webhookdb/api/saved_views.rb
+++ b/lib/webhookdb/api/saved_views.rb
@@ -3,6 +3,8 @@
 require "webhookdb/api"
 
 class Webhookdb::API::SavedViews < Webhookdb::API::V1
+  include Webhookdb::Service::Types
+
   resource :organizations do
     route_param :org_identifier do
       resource :saved_views do
@@ -34,7 +36,7 @@ class Webhookdb::API::SavedViews < Webhookdb::API::V1
         desc "Creates or replaces the view with the given name."
         params do
           optional :name,
-                   type: String,
+                   type: TrimmedString,
                    prompt: "Enter the view name (alphanumeric, spaces, underscores):"
           optional :sql, type: String, prompt: "Enter the SQL you would like to run:"
         end

--- a/lib/webhookdb/api/service_integrations.rb
+++ b/lib/webhookdb/api/service_integrations.rb
@@ -10,6 +10,8 @@ require "webhookdb/async/audit_logger"
 require "webhookdb/jobs/process_webhook"
 
 class Webhookdb::API::ServiceIntegrations < Webhookdb::API::V1
+  include Webhookdb::Service::Types
+
   # These URLs are not used by the CLI-
   # they are the url that customers should point their webhooks to.
   # We can't check org permissions on this endpoint
@@ -101,7 +103,7 @@ If the list does not look correct, you can contact support at #{Webhookdb.suppor
           end
           desc "Create service integration on a given organization"
           params do
-            optional :service_name, type: String,
+            optional :service_name, type: TrimmedString,
                                     prompt: "Enter the name of the service to create an integration for.\n" \
                                             "Run 'webhookdb services list' to see available services:"
             optional :guard_confirm
@@ -187,7 +189,9 @@ If the list does not look correct, you can contact support at #{Webhookdb.suppor
 
           desc "Returns information about the integration."
           params do
-            optional :field, type: String, values: Webhookdb::ServiceIntegration::INTEGRATION_INFO_FIELDS.keys + [""]
+            optional :field,
+                     type: TrimmedString,
+                     values: TrimmedString.map(Webhookdb::ServiceIntegration::INTEGRATION_INFO_FIELDS.keys + [""])
           end
           post :info do
             ensure_plan_supports!
@@ -339,7 +343,7 @@ If the list does not look correct, you can contact support at #{Webhookdb.suppor
           end
 
           params do
-            optional :confirm, type: String
+            optional :confirm, type: TrimmedString
           end
           post :delete do
             ensure_plan_supports!
@@ -384,9 +388,11 @@ The tables and all data for this integration and its dependents will also be rem
 
           params do
             optional :new_name,
-                     type: String,
+                     type: TrimmedString,
                      db_identifier: true,
-                     prompt: "Enter the new name of the table. " + Webhookdb::DBAdapter::INVALID_IDENTIFIER_MESSAGE
+                     prompt: "Enter the new name of the table. " +
+                       Webhookdb::DBAdapter::INVALID_IDENTIFIER_PROMPT +
+                       "\nTable name:"
           end
           post :rename_table do
             org = lookup_org!

--- a/lib/webhookdb/api/subscriptions.rb
+++ b/lib/webhookdb/api/subscriptions.rb
@@ -6,6 +6,8 @@ require "webhookdb/api"
 require "webhookdb/admin_api"
 
 class Webhookdb::API::Subscriptions < Webhookdb::API::V1
+  include Webhookdb::Service::Types
+
   resource :organizations do
     route_param :org_identifier, type: String do
       resource :subscriptions do
@@ -19,7 +21,7 @@ class Webhookdb::API::Subscriptions < Webhookdb::API::V1
 
         desc "Authenticates stripe user and returns stripe checkout session or billing portal url"
         params do
-          optional :plan, type: String
+          optional :plan, type: TrimmedString
           optional :guard_confirm
         end
         post :open_portal do

--- a/lib/webhookdb/api/sync_targets.rb
+++ b/lib/webhookdb/api/sync_targets.rb
@@ -5,6 +5,8 @@ require "webhookdb/jobs/sync_target_run_sync"
 
 # rubocop:disable Layout/LineLength
 class Webhookdb::API::SyncTargets < Webhookdb::API::V1
+  include Webhookdb::Service::Types
+
   class ConnectionUrlType < Grape::Validations::Validators::Base
     def validate!(params)
       url = params[:connection_url]
@@ -46,14 +48,14 @@ class Webhookdb::API::SyncTargets < Webhookdb::API::V1
                            disable: ->(req) { req.path.end_with?("/update") },
                          }
                 is_db && optional(:schema,
-                                  type: String,
+                                  type: TrimmedString,
                                   db_identifier: true,
                                   allow_blank: true,
                                   desc: "Schema (or namespace) to write the table into. Default to no schema/namespace.",)
                 # The description here says there is a default value, but the default value isn't actually saved to the SyncTarget
                 # object--it's inferred in the SyncTarget sync behavior when the table value is a blank string.
                 is_db && optional(:table,
-                                  type: String,
+                                  type: TrimmedString,
                                   db_identifier: true,
                                   allow_blank: true,
                                   desc: "Table to create and update. Default to match the table name of the service integration.",)
@@ -64,7 +66,7 @@ class Webhookdb::API::SyncTargets < Webhookdb::API::V1
               end
               params :connection_url do
                 optional :connection_url,
-                         type: String,
+                         type: TrimmedString,
                          prompt: "Enter the #{is_db ? 'database connection string' : 'HTTP endpoint'} that WebhookDB should sync data to:",
                          connection_url_type: is_db ? "db" : "http"
               end
@@ -112,7 +114,7 @@ class Webhookdb::API::SyncTargets < Webhookdb::API::V1
             params do
               use :connection_url
               use :sync_target_params
-              requires :service_integration_identifier, type: String, allow_blank: false
+              requires :service_integration_identifier, type: TrimmedString, allow_blank: false
             end
             route_setting :target_type, target_type_resource
             post :create do
@@ -153,8 +155,8 @@ class Webhookdb::API::SyncTargets < Webhookdb::API::V1
                 end
               end
               params do
-                optional :user, type: String, prompt: "Username for the connection:"
-                optional :password, type: String, prompt: "Password for the connection:"
+                optional :user, type: TrimmedString, prompt: "Username for the connection:"
+                optional :password, type: TrimmedString, prompt: "Password for the connection:"
               end
               route_setting :target_type, target_type_resource
               post :update_credentials do
@@ -187,7 +189,7 @@ class Webhookdb::API::SyncTargets < Webhookdb::API::V1
               end
 
               params do
-                optional :confirm, type: String
+                optional :confirm, type: TrimmedString
               end
               route_setting :target_type, target_type_resource
               post :delete do

--- a/lib/webhookdb/api/webhook_subscriptions.rb
+++ b/lib/webhookdb/api/webhook_subscriptions.rb
@@ -3,6 +3,8 @@
 require "webhookdb/api"
 
 class Webhookdb::API::WebhookSubscriptions < Webhookdb::API::V1
+  include Webhookdb::Service::Types
+
   resource :organizations do
     route_param :org_identifier, type: String do
       resource :webhook_subscriptions do
@@ -21,7 +23,7 @@ class Webhookdb::API::WebhookSubscriptions < Webhookdb::API::V1
 
         params do
           optional :service_integration_identifier,
-                   type: String,
+                   type: TrimmedString,
                    desc: "If provided, attach the webhook subscription to this integration rather than the org.",
                    prompt: "Which integration is this for? Use the service name, table name, or opaque id.\n" \
                            "See your integrations with `webhookdb integrations list`:"

--- a/lib/webhookdb/service/types.rb
+++ b/lib/webhookdb/service/types.rb
@@ -7,18 +7,20 @@ module Webhookdb::Service::Types
     ctx.const_set(:NormalizedEmail, NormalizedEmail)
     ctx.const_set(:NormalizedPhone, NormalizedPhone)
     ctx.const_set(:CommaSepArray, CommaSepArray)
+    ctx.const_set(:TrimmedString, TrimmedString)
   end
 
-  class NormalizedEmail
-    def self.parse(value)
-      return value.downcase.strip
-    end
+  class NormalizedEmail < String
+    def self.parse(value) = self.new(value.downcase.strip)
   end
 
-  class NormalizedPhone
-    def self.parse(value)
-      return Webhookdb::PhoneNumber::US.normalize(value)
-    end
+  class NormalizedPhone < String
+    def self.parse(value) = self.new(Webhookdb::PhoneNumber::US.normalize(value))
+  end
+
+  class TrimmedString < String
+    def self.parse(value) = self.new(value.strip)
+    def self.map(arr) = arr.map { |a| self.new(a) }
   end
 
   class CommaSepArray

--- a/spec/webhookdb/service_spec.rb
+++ b/spec/webhookdb/service_spec.rb
@@ -62,21 +62,23 @@ class Webhookdb::API::TestService < Webhookdb::Service
   end
 
   params do
-    requires :email, type: String, coerce_with: NormalizedEmail
-    requires :phone, type: String, coerce_with: NormalizedPhone
+    requires :email, type: NormalizedEmail
+    requires :phone, type: NormalizedPhone
+    requires :trimstr, type: TrimmedString
     requires :arr, type: [String], coerce_with: CommaSepArray
   end
   get :custom_types do
-    present({email: params[:email], phone: params[:phone], arr: params[:arr]})
+    present({email: params[:email], phone: params[:phone], arr: params[:arr], trimstr: params[:trimstr]})
   end
   params do
-    requires :email, type: String, coerce_with: NormalizedEmail
-    requires :phone, type: String, coerce_with: NormalizedPhone
+    requires :email, type: NormalizedEmail
+    requires :phone, type: NormalizedPhone
+    requires :trimstr, type: TrimmedString
     requires :arr, type: [String], coerce_with: CommaSepArray
   end
   post :custom_types do
     status 200
-    present({email: params[:email], phone: params[:phone], arr: params[:arr]})
+    present({email: params[:email], phone: params[:phone], arr: params[:arr], trimstr: params[:trimstr]})
   end
 
   params do
@@ -638,32 +640,35 @@ RSpec.describe Webhookdb::Service, :db do
 
   describe "custom types" do
     it "works with custom types" do
-      get "/custom_types?email= x@Y.Z &phone=555-111-2222&arr=1,2,a"
+      get "/custom_types?email= x@Y.Z &phone=555-111-2222&arr=1,2,a&trimstr=%20abc%20"
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(
         email: "x@y.z",
         phone: "15551112222",
         arr: ["1", "2", "a"],
+        trimstr: "abc",
       )
     end
 
     it "POST works with custom types" do
-      post "/custom_types", {email: " x@Y.Z ", phone: "555-111-2222", arr: "1,2,a"}
+      post "/custom_types", {email: " x@Y.Z ", phone: "555-111-2222", arr: "1,2,a", trimstr: " abc "}
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(
         email: "x@y.z",
         phone: "15551112222",
         arr: ["1", "2", "a"],
+        trimstr: "abc",
       )
     end
 
     it "POST works with actual arrays" do
-      post "/custom_types", {email: " x@Y.Z ", phone: "555-111-2222", arr: ["1", "2", "a"]}
+      post "/custom_types", {email: " x@Y.Z ", phone: "555-111-2222", arr: ["1", "2", "a"], trimstr: ""}
       expect(last_response).to have_status(200)
       expect(last_response).to have_json_body.that_includes(
         email: "x@y.z",
         phone: "15551112222",
         arr: ["1", "2", "a"],
+        trimstr: "",
       )
     end
   end


### PR DESCRIPTION
Some shells (one user is reporting iterm2 with zsh) are adding whitespace, either a new line or space, at the end of terminal prompts.

I'm not sure why this is, as I cannot reproduce it, but also, the API should be responsible for trimming whitespace.

This adds a new `TrimmedString` API type that can be used for any strings sent to the API that should have whitespace stripped before processing. For example, an httpsync connection url with trailing whitespace is an invalid URL.

Also modifies `NormalizedEmail` to be a subclass of String so it can be used directly in Grape's `type:`, rather than having to use `type: String, coerce_with: NormalizedEmail`.
