### PR TITLE
WebhookRequest#as_json should not jsonify Rack

### DIFF
--- a/lib/webhookdb/replicator/webhook_request.rb
+++ b/lib/webhookdb/replicator/webhook_request.rb
@@ -6,4 +6,12 @@ class Webhookdb::Replicator::WebhookRequest < Webhookdb::TypedStruct
   # When a webhook is processed synchronously, this will be set to the Rack::Request.
   # Normal (async) webhook processing does not have this available.
   attr_accessor :rack_request
+
+  JSON_KEYS = ["body", "headers", "path", "method"].freeze
+  def as_json
+    return JSON_KEYS.each_with_object({}) do |k, h|
+      v = self.send(k)
+      h[k] = v.as_json unless v.nil?
+    end
+  end
 end

--- a/spec/webhookdb/replicator/webhook_request_spec.rb
+++ b/spec/webhookdb/replicator/webhook_request_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Webhookdb::Replicator::WebhookRequest do
+  describe "as_json" do
+    it "does not include a Rack Request" do
+      w = described_class.new
+      expect(w.as_json).to eq({})
+
+      w = described_class.new(body: "x", headers: {"X" => "1"}, path: "/a", method: :GET)
+      expect(w.as_json).to eq({"body" => "x", "headers" => {"X" => "1"}, "method" => "GET", "path" => "/a"})
+
+      w.rack_request = Rack::Request.new({})
+      expect(w.as_json).to eq({"body" => "x", "headers" => {"X" => "1"}, "method" => "GET", "path" => "/a"})
+
+      # Create an invalid env to make sure it doesn't even attempt to serialize.
+      env = {x: 1}
+      env[:y] = env
+      w.rack_request = Rack::Request.new(env)
+      expect(w.as_json).to eq({"body" => "x", "headers" => {"X" => "1"}, "method" => "GET", "path" => "/a"})
+    end
+  end
+end


### PR DESCRIPTION
Trying to `as_json` on a `Rack::Request` will try to do `env.as_json` which can fail with a stack error
if `env` has a recursive hash (which is totally valid since `env` is not meant to serialize).

This excludes `WebhookRequest#rack_request` from
its `as_json` value.