### PR TITLE
Improve shared behavior parameters

### DIFF
--- a/spec/webhookdb/replicator/atom_single_feed_v1_spec.rb
+++ b/spec/webhookdb/replicator/atom_single_feed_v1_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Webhookdb::Replicator::AtomSingleFeedV1, :db do
     J
   end
 
-  it_behaves_like "a replicator", "atom_single_feed_v1" do
+  it_behaves_like "a replicator" do
     let(:sint) { super() }
     let(:body) { entry_hash }
     let(:expected_row) do
@@ -40,10 +40,9 @@ RSpec.describe Webhookdb::Replicator::AtomSingleFeedV1, :db do
         geo_lng: BigDecimal("-122.646064077"),
       )
     end
-    let(:supports_row_diff) { true }
   end
 
-  it_behaves_like "a replicator that may have a minimal body", "atom_single_feed_v1" do
+  it_behaves_like "a replicator that may have a minimal body" do
     let(:body) do
       Webhookdb::Xml::Atom.parse_entry(<<~J)
         <entry>
@@ -55,7 +54,7 @@ RSpec.describe Webhookdb::Replicator::AtomSingleFeedV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "atom_single_feed_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) { entry_hash }
     let(:new_body) { entry_hash.merge("updated" => "Fri, 10 Jun 2023 17:40:38 PST", "title" => "new title") }
   end
@@ -89,7 +88,7 @@ RSpec.describe Webhookdb::Replicator::AtomSingleFeedV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "atom_single_feed_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~J
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:georss="http://www.georss.org/georss">

--- a/spec/webhookdb/replicator/convertkit_broadcast_v1_spec.rb
+++ b/spec/webhookdb/replicator/convertkit_broadcast_v1_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Webhookdb::Replicator::ConvertkitBroadcastV1, :db do
       )
   end
 
-  it_behaves_like "a replicator", "convertkit_broadcast_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -58,7 +58,7 @@ RSpec.describe Webhookdb::Replicator::ConvertkitBroadcastV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "convertkit_broadcast_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {
@@ -155,7 +155,7 @@ RSpec.describe Webhookdb::Replicator::ConvertkitBroadcastV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that uses enrichments", "convertkit_broadcast_v1" do
+  it_behaves_like "a replicator that uses enrichments" do
     let(:body) do
       JSON.parse(<<~J)
         {

--- a/spec/webhookdb/replicator/convertkit_subscriber_v1_spec.rb
+++ b/spec/webhookdb/replicator/convertkit_subscriber_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::ConvertkitSubscriberV1, :db do
-  it_behaves_like "a replicator", "convertkit_subscriber_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -58,7 +58,7 @@ RSpec.describe Webhookdb::Replicator::ConvertkitSubscriberV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "convertkit_subscriber_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {
@@ -186,7 +186,7 @@ RSpec.describe Webhookdb::Replicator::ConvertkitSubscriberV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "convertkit_subscriber_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/convertkit_tag_v1_spec.rb
+++ b/spec/webhookdb/replicator/convertkit_tag_v1_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Webhookdb::Replicator::ConvertkitTagV1, :db do
       )
   end
 
-  it_behaves_like "a replicator", "convertkit_tag_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -61,7 +61,7 @@ RSpec.describe Webhookdb::Replicator::ConvertkitTagV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "convertkit_tag_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {
@@ -150,7 +150,7 @@ RSpec.describe Webhookdb::Replicator::ConvertkitTagV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that uses enrichments", "convertkit_tag_v1" do
+  it_behaves_like "a replicator that uses enrichments" do
     let(:body) do
       JSON.parse(<<~J)
         {

--- a/spec/webhookdb/replicator/email_octopus_campaign_v1_spec.rb
+++ b/spec/webhookdb/replicator/email_octopus_campaign_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::EmailOctopusCampaignV1, :db do
-  it_behaves_like "a replicator", "email_octopus_campaign_v1" do
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -28,15 +28,13 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusCampaignV1, :db do
         }
       J
     end
-    let(:supports_row_diff) { false }
   end
 
-  it_behaves_like "a replicator dependent on another", "email_octopus_campaign_v1",
-                  "email_octopus_list_v1" do
+  it_behaves_like "a replicator dependent on another", "email_octopus_list_v1" do
     let(:no_dependencies_message) { "This integration requires Email Octopus Lists to sync" }
   end
 
-  it_behaves_like "a replicator that can backfill", "email_octopus_campaign_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:org) { Webhookdb::Fixtures.organization.create }
     let(:list_sint) do
       Webhookdb::Fixtures.service_integration.create(

--- a/spec/webhookdb/replicator/email_octopus_contact_v1_spec.rb
+++ b/spec/webhookdb/replicator/email_octopus_contact_v1_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusContactV1, :db do
   end
   let(:svc) { Webhookdb::Replicator.create(sint) }
 
-  it_behaves_like "a replicator", "email_octopus_contact_v1" do
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -39,15 +39,13 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusContactV1, :db do
         }
       J
     end
-    let(:supports_row_diff) { false }
   end
 
-  it_behaves_like "a replicator dependent on another", "email_octopus_contact_v1",
-                  "email_octopus_list_v1" do
+  it_behaves_like "a replicator dependent on another", "email_octopus_list_v1" do
     let(:no_dependencies_message) { "This integration requires Email Octopus Lists to sync" }
   end
 
-  it_behaves_like "a replicator that can backfill", "email_octopus_contact_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:empty_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/email_octopus_event_v1_spec.rb
+++ b/spec/webhookdb/replicator/email_octopus_event_v1_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusEventV1, :db do
   end
   let(:contact_svc) { Webhookdb::Replicator.create(contact_sint) }
 
-  it_behaves_like "a replicator", "email_octopus_event_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -54,12 +54,11 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusEventV1, :db do
     end
   end
 
-  it_behaves_like "a replicator dependent on another", "email_octopus_event_v1",
-                  "email_octopus_list_v1" do
+  it_behaves_like "a replicator dependent on another", "email_octopus_list_v1" do
     let(:no_dependencies_message) { "This integration requires Email Octopus Lists to sync" }
   end
 
-  it_behaves_like "a replicator that can backfill", "email_octopus_event_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:empty_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/email_octopus_list_v1_spec.rb
+++ b/spec/webhookdb/replicator/email_octopus_list_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::EmailOctopusListV1, :db do
-  it_behaves_like "a replicator", "email_octopus_list_v1" do
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -39,7 +39,6 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusListV1, :db do
         }
       J
     end
-    let(:supports_row_diff) { false }
   end
 
   it_behaves_like "a replicator that verifies backfill secrets" do
@@ -76,7 +75,7 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusListV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "email_octopus_list_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:empty_response) do
       <<~R
         {
@@ -199,7 +198,7 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusListV1, :db do
     end
   end
 
-  it_behaves_like "a replicator with dependents", "email_octopus_list_v1", "email_octopus_contact_v1" do
+  it_behaves_like "a replicator with dependents", "email_octopus_contact_v1" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -230,7 +229,7 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusListV1, :db do
       }
     end
   end
-  it_behaves_like "a replicator with dependents", "email_octopus_list_v1", "email_octopus_campaign_v1" do
+  it_behaves_like "a replicator with dependents", "email_octopus_campaign_v1" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -262,7 +261,7 @@ RSpec.describe Webhookdb::Replicator::EmailOctopusListV1, :db do
     end
   end
 
-  it_behaves_like "a replicator with dependents", "email_octopus_list_v1", "email_octopus_event_v1" do
+  it_behaves_like "a replicator with dependents", "email_octopus_event_v1" do
     let(:body) do
       JSON.parse(<<~J)
         {

--- a/spec/webhookdb/replicator/fake_spec.rb
+++ b/spec/webhookdb/replicator/fake_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "fake implementations", :db do
       described_class.reset
     end
 
-    it_behaves_like "a replicator", "fake_v1" do
+    it_behaves_like "a replicator" do
       let(:body) do
         {
           "my_id" => "abc",
@@ -23,7 +23,7 @@ RSpec.describe "fake implementations", :db do
       end
     end
 
-    it_behaves_like "a replicator that prevents overwriting new data with old", "fake_v1" do
+    it_behaves_like "a replicator that prevents overwriting new data with old" do
       let(:old_body) do
         {
           "my_id" => "abc",
@@ -38,7 +38,7 @@ RSpec.describe "fake implementations", :db do
       end
     end
 
-    it_behaves_like "a replicator that can backfill", "fake_v1" do
+    it_behaves_like "a replicator that can backfill" do
       let(:page1_items) do
         [
           {"my_id" => "1", "at" => "Thu, 30 Jul 2015 21:12:33 +0000"},
@@ -74,7 +74,7 @@ RSpec.describe "fake implementations", :db do
       end
     end
 
-    it_behaves_like "a replicator that upserts webhooks only under specific conditions", "fake_v1" do
+    it_behaves_like "a replicator that upserts webhooks only under specific conditions" do
       before(:each) do
         described_class.resource_and_event_hook = ->(_h) {}
       end
@@ -87,7 +87,7 @@ RSpec.describe "fake implementations", :db do
       end
     end
 
-    it_behaves_like "a replicator with dependents", "fake_v1", "fake_dependent_v1" do
+    it_behaves_like "a replicator with dependents", "fake_dependent_v1" do
       let(:body) do
         {
           "my_id" => "abc",
@@ -167,7 +167,7 @@ RSpec.describe "fake implementations", :db do
       described_class.reset
     end
 
-    it_behaves_like "a replicator that uses enrichments", "fake_with_enrichments_v1" do
+    it_behaves_like "a replicator that uses enrichments" do
       let(:body) { {"my_id" => "abc", "at" => "Thu, 30 Jul 2015 21:12:33 +0000"} }
       let(:enrichment_body) { {extra: "abc"}.to_json }
       let(:expected_enrichment_data) { JSON.parse(enrichment_body) }
@@ -197,7 +197,7 @@ RSpec.describe "fake implementations", :db do
       described_class.reset
     end
 
-    it_behaves_like "a replicator dependent on another", "fake_dependent_v1", "fake_v1" do
+    it_behaves_like "a replicator dependent on another", "fake_v1" do
       let(:no_dependencies_message) { "You don't have any Fake integrations yet. You can run:" }
     end
   end
@@ -211,8 +211,8 @@ RSpec.describe "fake implementations", :db do
       described_class.reset
     end
 
-    it_behaves_like "a replicator dependent on another", "fake_dependent_v1", "fake_v1" do
-      let(:no_dependencies_message) { "You don't have any Fake integrations yet. You can run:" }
+    it_behaves_like "a replicator dependent on another", "fake_dependent_v1" do
+      let(:no_dependencies_message) { "You don't have any FakeDependent integrations yet. You can run:" }
     end
   end
 

--- a/spec/webhookdb/replicator/front_conversation_v1_spec.rb
+++ b/spec/webhookdb/replicator/front_conversation_v1_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Webhookdb::Replicator::FrontConversationV1, :db do
   let(:sint) { fac.depending_on(root).create(service_name: "front_conversation_v1").refresh }
   let(:svc) { sint.replicator }
 
-  it_behaves_like "a replicator", "front_conversation_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {

--- a/spec/webhookdb/replicator/front_message_v1_spec.rb
+++ b/spec/webhookdb/replicator/front_message_v1_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Webhookdb::Replicator::FrontMessageV1, :db do
   let(:sint) { fac.depending_on(root).create(service_name: "front_message_v1").refresh }
   let(:svc) { sint.replicator }
 
-  it_behaves_like "a replicator", "front_message_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {

--- a/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
+++ b/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
@@ -3,16 +3,14 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1, :db do
-  service_name = "front_signalwire_message_channel_app_v1"
   let(:org) { Webhookdb::Fixtures.organization.create }
   let(:fac) { Webhookdb::Fixtures.service_integration(organization: org) }
   let(:signalwire_sint) { fac.create(service_name: "signalwire_message_v1") }
-  let(:sint) { fac.depending_on(signalwire_sint).create(service_name:) }
+  let(:sint) { fac.depending_on(signalwire_sint).create(service_name: "front_signalwire_message_channel_app_v1") }
   let(:svc) { sint.replicator }
 
-  it_behaves_like "a replicator", service_name do
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:sint) { super().update(api_url: "2223334444") }
-    let(:supports_row_diff) { false }
     let(:body) do
       {
         "type" => "message_autoreply",
@@ -54,7 +52,7 @@ RSpec.describe Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1, :db do
     end
   end
 
-  it_behaves_like "a replicator dependent on another", service_name, "signalwire_message_v1" do
+  it_behaves_like "a replicator dependent on another", "signalwire_message_v1" do
     let(:no_dependencies_message) { "This integration requires SignalWire Messages to sync" }
   end
 

--- a/spec/webhookdb/replicator/github_issue_comment_v1_spec.rb
+++ b/spec/webhookdb/replicator/github_issue_comment_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::GithubIssueCommentV1, :db do
-  it_behaves_like "a replicator", "github_issue_comment_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -25,7 +25,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueCommentV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "github_issue_comment_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~JSON)
         {
@@ -66,7 +66,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueCommentV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that may have a minimal body", "github_issue_comment_v1" do
+  it_behaves_like "a replicator that may have a minimal body" do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -83,7 +83,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueCommentV1, :db do
       JSON
     end
   end
-  it_behaves_like "a replicator that deals with resources and wrapped events", "github_issue_comment_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.fetch("comment") }
     let(:resource_in_envelope_headers) { {"X-Github-Hook-Id" => "1"} }
     let(:resource_in_envelope_json) do
@@ -114,7 +114,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueCommentV1, :db do
   # This is tested through github_issue_v1
   # it_behaves_like "a replicator that verifies backfill secrets"
 
-  it_behaves_like "a replicator that can backfill", "github_issue_comment_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:api_url) { "my/code" }
     let(:page1_response) do
       <<~JSON
@@ -203,7 +203,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueCommentV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "github_issue_comment_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:api_url) { "my/code" }
     let(:today) { Time.parse("2020-11-22T18:00:00Z") }
     let(:page1_response) do

--- a/spec/webhookdb/replicator/github_issue_v1_spec.rb
+++ b/spec/webhookdb/replicator/github_issue_v1_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueV1, :db do
   let(:accept_json_contenttype) { "application/vnd.github+json" }
   let(:response_json_contenttype) { ["application/json; charset=utf-8", accept_json_contenttype].sample }
 
-  it_behaves_like "a replicator", "github_issue_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -83,7 +83,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "github_issue_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~JSON)
         {
@@ -234,7 +234,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that may have a minimal body", "github_issue_v1" do
+  it_behaves_like "a replicator that may have a minimal body" do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -263,7 +263,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueV1, :db do
       JSON
     end
   end
-  it_behaves_like "a replicator that deals with resources and wrapped events", "github_issue_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.fetch("issue") }
     let(:resource_in_envelope_headers) { {"X-Github-Hook-Id" => "1"} }
     let(:resource_in_envelope_json) do
@@ -305,7 +305,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that uses enrichments", "github_issue_v1", stores_enrichment_column: false do
+  it_behaves_like "a replicator that uses enrichments", stores_enrichment_column: false do
     # super() is not working here for some reason
     let(:sint) { Webhookdb::Fixtures.service_integration.create(service_name: "github_issue_v1", backfill_secret: "x") }
     let(:body) do
@@ -396,7 +396,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueV1, :db do
           to_return(status: 401, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "github_issue_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:api_url) { "my/code" }
     let(:page1_response) do
       <<~JSON
@@ -525,7 +525,7 @@ RSpec.describe Webhookdb::Replicator::GithubIssueV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "github_issue_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:api_url) { "my/code" }
     let(:today) { Time.parse("2020-11-22T18:00:00Z") }
     let(:page1_response) do

--- a/spec/webhookdb/replicator/github_pull_v1_spec.rb
+++ b/spec/webhookdb/replicator/github_pull_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::GithubPullV1, :db do
-  it_behaves_like "a replicator", "github_pull_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -114,7 +114,7 @@ RSpec.describe Webhookdb::Replicator::GithubPullV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "github_pull_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~JSON)
         {
@@ -171,7 +171,7 @@ RSpec.describe Webhookdb::Replicator::GithubPullV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that may have a minimal body", "github_pull_v1" do
+  it_behaves_like "a replicator that may have a minimal body" do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -201,7 +201,7 @@ RSpec.describe Webhookdb::Replicator::GithubPullV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "github_pull_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.fetch("pull_request") }
     let(:resource_in_envelope_headers) { {"X-Github-Hook-Id" => "1"} }
     let(:resource_in_envelope_json) do
@@ -237,7 +237,7 @@ RSpec.describe Webhookdb::Replicator::GithubPullV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that uses enrichments", "github_pull_v1", stores_enrichment_column: false do
+  it_behaves_like "a replicator that uses enrichments", stores_enrichment_column: false do
     let(:sint) { Webhookdb::Fixtures.service_integration.create(service_name: "github_pull_v1", backfill_secret: "x") }
     let(:body) do
       JSON.parse(<<~JSON)
@@ -278,7 +278,7 @@ RSpec.describe Webhookdb::Replicator::GithubPullV1, :db do
   # This is tested through github_issue_v1
   # it_behaves_like "a replicator that verifies backfill secrets"
 
-  it_behaves_like "a replicator that can backfill", "github_pull_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:api_url) { "my/code" }
     let(:page1_response) do
       <<~JSON
@@ -391,7 +391,7 @@ RSpec.describe Webhookdb::Replicator::GithubPullV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "github_pull_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:api_url) { "my/code" }
     let(:today) { Time.parse("2020-11-22T18:00:00Z") }
     let(:page1_response) do

--- a/spec/webhookdb/replicator/github_release_v1_spec.rb
+++ b/spec/webhookdb/replicator/github_release_v1_spec.rb
@@ -3,8 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::GithubReleaseV1, :db do
-  it_behaves_like "a replicator", "github_release_v1" do
-    let(:supports_row_diff) { false }
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -35,9 +34,9 @@ RSpec.describe Webhookdb::Replicator::GithubReleaseV1, :db do
   end
 
   # Not supported for releases, we always stomp
-  # it_behaves_like "a replicator that prevents overwriting new data with old", "github_release_v1"
+  # it_behaves_like "a replicator that prevents overwriting new data with old"
 
-  it_behaves_like "a replicator that may have a minimal body", "github_release_v1" do
+  it_behaves_like "a replicator that may have a minimal body" do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -55,7 +54,7 @@ RSpec.describe Webhookdb::Replicator::GithubReleaseV1, :db do
       JSON
     end
   end
-  it_behaves_like "a replicator that deals with resources and wrapped events", "github_release_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.fetch("release") }
     let(:resource_in_envelope_headers) { {"X-Github-Hook-Id" => "1"} }
     let(:resource_in_envelope_json) do
@@ -94,7 +93,7 @@ RSpec.describe Webhookdb::Replicator::GithubReleaseV1, :db do
   # This is tested through github_issue_v1
   # it_behaves_like "a replicator that verifies backfill secrets"
 
-  it_behaves_like "a replicator that can backfill", "github_release_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:api_url) { "my/code" }
     let(:page1_response) do
       <<~JSON
@@ -175,7 +174,7 @@ RSpec.describe Webhookdb::Replicator::GithubReleaseV1, :db do
   end
 
   # Not supported for releases
-  # it_behaves_like "a replicator that can backfill incrementally", "github_release_v1"
+  # it_behaves_like "a replicator that can backfill incrementally"
 
   # Tested through github_issue
   # describe "webhook validation"

--- a/spec/webhookdb/replicator/github_repository_event_v1_spec.rb
+++ b/spec/webhookdb/replicator/github_repository_event_v1_spec.rb
@@ -3,8 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::GithubRepositoryEventV1, :db do
-  it_behaves_like "a replicator", "github_repository_event_v1" do
-    let(:supports_row_diff) { false }
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -37,9 +36,9 @@ RSpec.describe Webhookdb::Replicator::GithubRepositoryEventV1, :db do
   end
 
   # Events are (I think) immutable
-  # it_behaves_like "a replicator that prevents overwriting new data with old", "github_repository_event_v1"
+  # it_behaves_like "a replicator that prevents overwriting new data with old"
 
-  it_behaves_like "a replicator that may have a minimal body", "github_repository_event_v1" do
+  it_behaves_like "a replicator that may have a minimal body" do
     let(:body) do
       JSON.parse(<<~JSON)
         {
@@ -53,12 +52,12 @@ RSpec.describe Webhookdb::Replicator::GithubRepositoryEventV1, :db do
   end
 
   # Activity events are backfill-only
-  # it_behaves_like "a replicator that deals with resources and wrapped events", "github_repository_event_v1"
+  # it_behaves_like "a replicator that deals with resources and wrapped events"
 
   # This is tested through github_issue_v1
   # it_behaves_like "a replicator that verifies backfill secrets"
 
-  it_behaves_like "a replicator that can backfill", "github_repository_event_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:api_url) { "my/code" }
     let(:page1_response) do
       <<~JSON
@@ -177,7 +176,7 @@ RSpec.describe Webhookdb::Replicator::GithubRepositoryEventV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "github_repository_event_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:api_url) { "my/code" }
     let(:today) { Time.parse("2020-11-22T18:00:00Z") }
     let(:page1_response) do

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
     end
   end
 
-  it_behaves_like "a replicator", "icalendar_calendar_v1" do
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:sint) { super() }
     let(:body) do
       JSON.parse(<<~J)
@@ -46,10 +46,9 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
         last_synced_at: nil,
       )
     end
-    let(:supports_row_diff) { false }
   end
 
-  it_behaves_like "a replicator with dependents", "icalendar_calendar_v1", "icalendar_event_v1" do
+  it_behaves_like "a replicator with dependents", "icalendar_event_v1" do
     let(:sint) { super() }
     let(:body) do
       JSON.parse(<<~J)
@@ -199,7 +198,7 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
     end
   end
 
-  it_behaves_like "a replicator with a custom backfill not supported message", "icalendar_calendar_v1"
+  it_behaves_like "a replicator with a custom backfill not supported message"
 
   describe "webhook_response" do
     it "validates using Whdb-Webhook-Secret" do

--- a/spec/webhookdb/replicator/icalendar_event_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_event_v1_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Webhookdb::Replicator::IcalendarEventV1, :db do
   let(:calendar_external_id) { "123" }
   let(:ics_url) { "https://spec.test" }
 
-  it_behaves_like "a replicator", "icalendar_event_v1" do
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:body) do
       s = <<~ICAL
         BEGIN:VEVENT
@@ -36,14 +36,13 @@ RSpec.describe Webhookdb::Replicator::IcalendarEventV1, :db do
         uid: "79396C44-9EA7-4EF0-A99F-5EFCE7764CFE",
       )
     end
-    let(:supports_row_diff) { false }
   end
 
-  it_behaves_like "a replicator dependent on another", "icalendar_event_v1", "icalendar_calendar_v1" do
+  it_behaves_like "a replicator dependent on another", "icalendar_calendar_v1" do
     let(:no_dependencies_message) { "" }
   end
 
-  it_behaves_like "a replicator with a custom backfill not supported message", "icalendar_event_v1"
+  it_behaves_like "a replicator with a custom backfill not supported message"
 
   describe "upsert" do
     def upsert(s)

--- a/spec/webhookdb/replicator/increase_event_v1_spec.rb
+++ b/spec/webhookdb/replicator/increase_event_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::IncreaseEventV1, :db do
-  it_behaves_like "a replicator", "increase_event_v1" do
+  it_behaves_like "a replicator" do
     let(:body) { JSON.parse(<<~JSON) }
       {
         "id": "event_123abc",
@@ -16,7 +16,7 @@ RSpec.describe Webhookdb::Replicator::IncreaseEventV1, :db do
     JSON
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "increase_event_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) { JSON.parse(<<~JSON) }
       {
         "id": "transfer_event_123",
@@ -39,7 +39,7 @@ RSpec.describe Webhookdb::Replicator::IncreaseEventV1, :db do
     JSON
   end
 
-  it_behaves_like "a replicator that can backfill", "increase_event_v1" do
+  it_behaves_like "a replicator that can backfill" do
     def create_all_dependencies(sint)
       r = super
       sint.depends_on&.update(backfill_key: "bfkey", api_url: "https://api.increase.com")

--- a/spec/webhookdb/replicator/increase_shared_examples.rb
+++ b/spec/webhookdb/replicator/increase_shared_examples.rb
@@ -30,12 +30,12 @@ RSpec.shared_examples "an Increase replicator dependent on events and increase_a
     let(:body) { insertable_body }
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", name do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) { old_insertable_body }
     let(:new_body) { new_insertable_body }
   end
 
-  it_behaves_like "a replicator that uses enrichments", name, stores_enrichment_column: false do
+  it_behaves_like "a replicator that uses enrichments", stores_enrichment_column: false do
     before(:each) do
       create_all_dependencies(sint).first.update(backfill_key: "access-tok")
     end
@@ -66,7 +66,7 @@ RSpec.shared_examples "an Increase replicator dependent on events and increase_a
     end
   end
 
-  it_behaves_like "a replicator that can backfill", name do
+  it_behaves_like "a replicator that can backfill" do
     def create_all_dependencies(sint)
       r = super
       sint.depends_on.update(backfill_key: "access-tok")

--- a/spec/webhookdb/replicator/intercom_contact_v1_spec.rb
+++ b/spec/webhookdb/replicator/intercom_contact_v1_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Webhookdb::Replicator::IntercomContactV1, :db do
   let(:sint) { fac.depending_on(root).create(service_name: "intercom_contact_v1").refresh }
   let(:svc) { sint.replicator }
 
-  it_behaves_like "a replicator", "intercom_contact_v1" do
+  it_behaves_like "a replicator" do
     let(:body) { JSON.parse(<<~JSON) }
       {
         "type": "contact",
@@ -130,7 +130,7 @@ RSpec.describe Webhookdb::Replicator::IntercomContactV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "intercom_contact_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "item") }
     let(:resource_in_envelope_json) { JSON.parse(<<~JSON) }
       {
@@ -247,7 +247,7 @@ RSpec.describe Webhookdb::Replicator::IntercomContactV1, :db do
     JSON
   end
 
-  it_behaves_like "a replicator that may have a minimal body", "intercom_contact_v1" do
+  it_behaves_like "a replicator that may have a minimal body" do
     let(:body) { JSON.parse(<<~JSON) }
       {
         "type": "notification_event",
@@ -299,11 +299,11 @@ RSpec.describe Webhookdb::Replicator::IntercomContactV1, :db do
     let(:other_bodies) { [archived_body] }
   end
 
-  it_behaves_like "a replicator dependent on another", "intercom_contact_v1", "intercom_marketplace_root_v1" do
+  it_behaves_like "a replicator dependent on another", "intercom_marketplace_root_v1" do
     let(:no_dependencies_message) { "This integration requires Intercom Auth to sync" }
   end
 
-  it_behaves_like "a replicator that can backfill", "intercom_contact_v1" do
+  it_behaves_like "a replicator that can backfill" do
     before(:each) { Webhookdb::Intercom.page_size = 2 }
 
     let(:page1_response) { <<~JSON }
@@ -688,7 +688,7 @@ RSpec.describe Webhookdb::Replicator::IntercomContactV1, :db do
     end
   end
 
-  it_behaves_like "a backfill replicator that requires credentials from a dependency", "intercom_contact_v1" do
+  it_behaves_like "a backfill replicator that requires credentials from a dependency" do
     let(:error_message) { /that the Intercom Auth integration has a valid Auth Token/ }
     def strip_auth(sint)
       sint.replicator.find_auth_integration.update(backfill_secret: "")

--- a/spec/webhookdb/replicator/intercom_conversation_v1_spec.rb
+++ b/spec/webhookdb/replicator/intercom_conversation_v1_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Webhookdb::Replicator::IntercomConversationV1, :db do
   let(:sint) { fac.depending_on(root).create(service_name: "intercom_conversation_v1").refresh }
   let(:svc) { sint.replicator }
 
-  it_behaves_like "a replicator", "intercom_conversation_v1" do
+  it_behaves_like "a replicator" do
     let(:body) { JSON.parse(<<~JSON) }
       {
         "type": "conversation",
@@ -158,7 +158,7 @@ RSpec.describe Webhookdb::Replicator::IntercomConversationV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "intercom_conversation_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "item") }
     let(:resource_in_envelope_json) { JSON.parse(<<~JSON) }
       {
@@ -309,7 +309,7 @@ RSpec.describe Webhookdb::Replicator::IntercomConversationV1, :db do
     JSON
   end
 
-  it_behaves_like "a replicator that may have a minimal body", "intercom_conversation_v1" do
+  it_behaves_like "a replicator that may have a minimal body" do
     let(:body) { JSON.parse(<<~JSON) }
       {
         "type": "notification_event",
@@ -377,11 +377,11 @@ RSpec.describe Webhookdb::Replicator::IntercomConversationV1, :db do
     let(:other_bodies) { [archived_body] }
   end
 
-  it_behaves_like "a replicator dependent on another", "intercom_conversation_v1", "intercom_marketplace_root_v1" do
+  it_behaves_like "a replicator dependent on another", "intercom_marketplace_root_v1" do
     let(:no_dependencies_message) { "This integration requires Intercom Auth to sync" }
   end
 
-  it_behaves_like "a replicator that can backfill", "intercom_conversation_v1" do
+  it_behaves_like "a replicator that can backfill" do
     before(:each) { Webhookdb::Intercom.page_size = 2 }
 
     let(:page1_response) { <<~JSON }
@@ -850,7 +850,7 @@ RSpec.describe Webhookdb::Replicator::IntercomConversationV1, :db do
     end
   end
 
-  it_behaves_like "a backfill replicator that requires credentials from a dependency", "intercom_conversation_v1" do
+  it_behaves_like "a backfill replicator that requires credentials from a dependency" do
     let(:error_message) { /that the Intercom Auth integration has a valid Auth Token/ }
     def strip_auth(sint)
       sint.replicator.find_auth_integration.update(backfill_secret: "")

--- a/spec/webhookdb/replicator/plivo_sms_inbound_v1_spec.rb
+++ b/spec/webhookdb/replicator/plivo_sms_inbound_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::PlivoSmsInboundV1, :db do
-  it_behaves_like "a replicator", "plivo_sms_inbound_v1" do
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:sint) do
       Webhookdb::Fixtures.service_integration.create(service_name: "plivo_sms_inbound_v1", backfill_secret: "x")
     end
@@ -39,7 +39,6 @@ RSpec.describe Webhookdb::Replicator::PlivoSmsInboundV1, :db do
         }
       JSON
     end
-    let(:supports_row_diff) { false }
   end
 
   describe "state machine calculation" do

--- a/spec/webhookdb/replicator/postmark_inbound_message_v1_spec.rb
+++ b/spec/webhookdb/replicator/postmark_inbound_message_v1_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Webhookdb::Replicator::PostmarkInboundMessageV1, :db do
     J
   end
 
-  it_behaves_like "a replicator", "postmark_inbound_message_v1" do
+  it_behaves_like "a replicator" do
     let(:body) { bod }
     let(:expected_data) { bod }
   end

--- a/spec/webhookdb/replicator/postmark_outbound_message_event_v1_spec.rb
+++ b/spec/webhookdb/replicator/postmark_outbound_message_event_v1_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe Webhookdb::Replicator::PostmarkOutboundMessageEventV1, :db do
 
   events.each do |(name, bod, _tsfield)|
     describe name do
-      it_behaves_like "a replicator", "postmark_outbound_message_event_v1" do
+      it_behaves_like "a replicator" do
         let(:body) { bod }
         let(:expected_data) { bod }
       end

--- a/spec/webhookdb/replicator/shopify_customer_v1_spec.rb
+++ b/spec/webhookdb/replicator/shopify_customer_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::ShopifyCustomerV1, :db do
-  it_behaves_like "a replicator", "shopify_customer_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -36,7 +36,7 @@ RSpec.describe Webhookdb::Replicator::ShopifyCustomerV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "shopify_customer_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -137,7 +137,7 @@ RSpec.describe Webhookdb::Replicator::ShopifyCustomerV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "shopify_customer_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/shopify_order_v1_spec.rb
+++ b/spec/webhookdb/replicator/shopify_order_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::ShopifyOrderV1, :db do
-  it_behaves_like "a replicator", "shopify_order_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -895,7 +895,7 @@ RSpec.describe Webhookdb::Replicator::ShopifyOrderV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "shopify_order_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -1898,7 +1898,7 @@ RSpec.describe Webhookdb::Replicator::ShopifyOrderV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "shopify_order_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/signalwire_message_v1_spec.rb
+++ b/spec/webhookdb/replicator/signalwire_message_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::SignalwireMessageV1, :db do
-  it_behaves_like "a replicator", "signalwire_message_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -34,7 +34,7 @@ RSpec.describe Webhookdb::Replicator::SignalwireMessageV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "signalwire_message_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -148,7 +148,7 @@ RSpec.describe Webhookdb::Replicator::SignalwireMessageV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "signalwire_message_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:api_url) { "whdbtestfake" }
     let(:today) { Time.parse("2020-11-22T18:00:00Z") }
     let(:page1_response) do
@@ -305,7 +305,7 @@ RSpec.describe Webhookdb::Replicator::SignalwireMessageV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "signalwire_message_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:api_url) { "whdbtestfake" }
     let(:today) { Time.parse("2020-11-22T18:00:00Z") }
     let(:page1_response) do

--- a/spec/webhookdb/replicator/sponsy_customer_v1_spec.rb
+++ b/spec/webhookdb/replicator/sponsy_customer_v1_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Webhookdb::Replicator::SponsyCustomerV1, :db do
   let(:sint) { fac.depending_on(slot_sint).create(service_name: "sponsy_customer_v1").refresh }
   let(:svc) { sint.replicator }
 
-  it_behaves_like "a replicator", "sponsy_customer_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -26,7 +26,7 @@ RSpec.describe Webhookdb::Replicator::SponsyCustomerV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that may have a minimal body", "sponsy_customer_v1" do
+  it_behaves_like "a replicator that may have a minimal body" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -39,7 +39,7 @@ RSpec.describe Webhookdb::Replicator::SponsyCustomerV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "sponsy_customer_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -70,11 +70,11 @@ RSpec.describe Webhookdb::Replicator::SponsyCustomerV1, :db do
     end
   end
 
-  it_behaves_like "a replicator dependent on another", "sponsy_customer_v1", "sponsy_slot_v1" do
+  it_behaves_like "a replicator dependent on another", "sponsy_slot_v1" do
     let(:no_dependencies_message) { "This integration requires Sponsy Slots to sync" }
   end
 
-  it_behaves_like "a replicator backfilling against the table of its dependency", "sponsy_customer_v1" do
+  it_behaves_like "a replicator backfilling against the table of its dependency" do
     let(:external_id_col) { :sponsy_id }
     def create_dependency_row(external_id, ts)
       return {

--- a/spec/webhookdb/replicator/sponsy_placement_v1_spec.rb
+++ b/spec/webhookdb/replicator/sponsy_placement_v1_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Webhookdb::Replicator::SponsyPlacementV1, :db do
     return {data:, cursor: {afterCursor: cursor}}.to_json
   end
 
-  it_behaves_like "a replicator", "sponsy_placement_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -59,7 +59,7 @@ RSpec.describe Webhookdb::Replicator::SponsyPlacementV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "sponsy_placement_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -90,11 +90,11 @@ RSpec.describe Webhookdb::Replicator::SponsyPlacementV1, :db do
     end
   end
 
-  it_behaves_like "a replicator dependent on another", "sponsy_placement_v1", "sponsy_publication_v1" do
+  it_behaves_like "a replicator dependent on another", "sponsy_publication_v1" do
     let(:no_dependencies_message) { "This integration requires Sponsy Publications to sync" }
   end
 
-  it_behaves_like "a replicator that can backfill", "sponsy_placement_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:expected_items_count) { 8 }
 
     def insert_required_data_callback
@@ -150,7 +150,7 @@ RSpec.describe Webhookdb::Replicator::SponsyPlacementV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "sponsy_placement_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:last_backfilled) { "2022-09-01T18:00:00Z" }
     let(:expected_new_items_count) { 4 }
     let(:expected_old_items_count) { 2 }
@@ -192,7 +192,7 @@ RSpec.describe Webhookdb::Replicator::SponsyPlacementV1, :db do
     end
   end
 
-  it_behaves_like "a backfill replicator that requires credentials from a dependency", "sponsy_placement_v1" do
+  it_behaves_like "a backfill replicator that requires credentials from a dependency" do
     let(:error_message) { /This Sponsy/ }
     def strip_auth(sint)
       sint.replicator.root_integration.update(backfill_secret: "")

--- a/spec/webhookdb/replicator/sponsy_publication_v1_spec.rb
+++ b/spec/webhookdb/replicator/sponsy_publication_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::SponsyPublicationV1, :db do
-  it_behaves_like "a replicator", "sponsy_publication_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -87,7 +87,7 @@ RSpec.describe Webhookdb::Replicator::SponsyPublicationV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "sponsy_publication_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -143,7 +143,7 @@ RSpec.describe Webhookdb::Replicator::SponsyPublicationV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "sponsy_publication_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {
@@ -242,7 +242,7 @@ RSpec.describe Webhookdb::Replicator::SponsyPublicationV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "sponsy_publication_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:last_backfilled) { "2022-09-01T18:00:00Z" }
     let(:expected_new_items_count) { 2 }
     let(:expected_old_items_count) { 1 }

--- a/spec/webhookdb/replicator/sponsy_slot_v1_spec.rb
+++ b/spec/webhookdb/replicator/sponsy_slot_v1_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Webhookdb::Replicator::SponsySlotV1, :db do
     return {data:, cursor: {afterCursor: cursor}}.to_json
   end
 
-  it_behaves_like "a replicator", "sponsy_slot_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -104,7 +104,7 @@ RSpec.describe Webhookdb::Replicator::SponsySlotV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "sponsy_slot_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -143,11 +143,11 @@ RSpec.describe Webhookdb::Replicator::SponsySlotV1, :db do
     end
   end
 
-  it_behaves_like "a replicator dependent on another", "sponsy_slot_v1", "sponsy_publication_v1" do
+  it_behaves_like "a replicator dependent on another", "sponsy_publication_v1" do
     let(:no_dependencies_message) { "This integration requires Sponsy Publications to sync" }
   end
 
-  it_behaves_like "a replicator that can backfill", "sponsy_slot_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:expected_items_count) { 8 }
 
     def insert_required_data_callback
@@ -203,7 +203,7 @@ RSpec.describe Webhookdb::Replicator::SponsySlotV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "sponsy_slot_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:last_backfilled) { "2022-09-01T18:00:00Z" }
     let(:expected_new_items_count) { 4 }
     let(:expected_old_items_count) { 2 }
@@ -245,7 +245,7 @@ RSpec.describe Webhookdb::Replicator::SponsySlotV1, :db do
     end
   end
 
-  it_behaves_like "a backfill replicator that requires credentials from a dependency", "sponsy_slot_v1" do
+  it_behaves_like "a backfill replicator that requires credentials from a dependency" do
     let(:error_message) { /This Sponsy/ }
     def strip_auth(sint)
       sint.replicator.root_integration.update(backfill_secret: "")

--- a/spec/webhookdb/replicator/sponsy_status_v1_spec.rb
+++ b/spec/webhookdb/replicator/sponsy_status_v1_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Webhookdb::Replicator::SponsyStatusV1, :db do
     return {data:, cursor: {afterCursor: cursor}}.to_json
   end
 
-  it_behaves_like "a replicator", "sponsy_status_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -59,7 +59,7 @@ RSpec.describe Webhookdb::Replicator::SponsyStatusV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "sponsy_status_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -90,11 +90,11 @@ RSpec.describe Webhookdb::Replicator::SponsyStatusV1, :db do
     end
   end
 
-  it_behaves_like "a replicator dependent on another", "sponsy_status_v1", "sponsy_publication_v1" do
+  it_behaves_like "a replicator dependent on another", "sponsy_publication_v1" do
     let(:no_dependencies_message) { "This integration requires Sponsy Publications to sync" }
   end
 
-  it_behaves_like "a replicator that can backfill", "sponsy_status_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:expected_items_count) { 8 }
 
     def insert_required_data_callback
@@ -150,7 +150,7 @@ RSpec.describe Webhookdb::Replicator::SponsyStatusV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "sponsy_status_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:last_backfilled) { "2022-09-01T18:00:00Z" }
     let(:expected_new_items_count) { 4 }
     let(:expected_old_items_count) { 2 }
@@ -192,7 +192,7 @@ RSpec.describe Webhookdb::Replicator::SponsyStatusV1, :db do
     end
   end
 
-  it_behaves_like "a backfill replicator that requires credentials from a dependency", "sponsy_status_v1" do
+  it_behaves_like "a backfill replicator that requires credentials from a dependency" do
     let(:error_message) { /This Sponsy/ }
     def strip_auth(sint)
       sint.replicator.root_integration.update(backfill_secret: "")

--- a/spec/webhookdb/replicator/stripe_charge_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_charge_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripeChargeV1, :db do
-  it_behaves_like "a replicator", "stripe_charge_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -145,7 +145,7 @@ RSpec.describe Webhookdb::Replicator::StripeChargeV1, :db do
     let(:expected_data) { body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_charge_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -430,7 +430,7 @@ RSpec.describe Webhookdb::Replicator::StripeChargeV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_charge_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -609,7 +609,7 @@ RSpec.describe Webhookdb::Replicator::StripeChargeV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "stripe_charge_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_coupon_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_coupon_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripeCouponV1, :db do
-  it_behaves_like "a replicator", "stripe_coupon_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -42,7 +42,7 @@ RSpec.describe Webhookdb::Replicator::StripeCouponV1, :db do
     end
     let(:expected_data) { body["data"]["object"] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_coupon_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -120,7 +120,7 @@ RSpec.describe Webhookdb::Replicator::StripeCouponV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_coupon_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -196,7 +196,7 @@ RSpec.describe Webhookdb::Replicator::StripeCouponV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_coupon_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_customer_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_customer_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripeCustomerV1, :db do
-  it_behaves_like "a replicator", "stripe_customer_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -135,7 +135,7 @@ RSpec.describe Webhookdb::Replicator::StripeCustomerV1, :db do
     end
     let(:expected_data) { body["data"]["object"] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_customer_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -346,7 +346,7 @@ RSpec.describe Webhookdb::Replicator::StripeCustomerV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_customer_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -435,7 +435,7 @@ RSpec.describe Webhookdb::Replicator::StripeCustomerV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_customer_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_dispute_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_dispute_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripeDisputeV1, :db do
-  it_behaves_like "a replicator", "stripe_dispute_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -75,7 +75,7 @@ RSpec.describe Webhookdb::Replicator::StripeDisputeV1, :db do
     end
     let(:expected_data) { body["data"]["object"] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_dispute_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -219,7 +219,7 @@ RSpec.describe Webhookdb::Replicator::StripeDisputeV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_dispute_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -328,7 +328,7 @@ RSpec.describe Webhookdb::Replicator::StripeDisputeV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_dispute_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_invoice_item_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_invoice_item_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripeInvoiceItemV1, :db do
-  it_behaves_like "a replicator", "stripe_invoice_item_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -70,7 +70,7 @@ RSpec.describe Webhookdb::Replicator::StripeInvoiceItemV1, :db do
     end
     let(:expected_data) { body["data"]["object"] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_invoice_item_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -204,7 +204,7 @@ RSpec.describe Webhookdb::Replicator::StripeInvoiceItemV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_invoice_item_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -308,7 +308,7 @@ RSpec.describe Webhookdb::Replicator::StripeInvoiceItemV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_invoice_item_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_invoice_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_invoice_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripeInvoiceV1, :db do
-  it_behaves_like "a replicator", "stripe_invoice_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -158,7 +158,7 @@ RSpec.describe Webhookdb::Replicator::StripeInvoiceV1, :db do
     end
     let(:expected_data) { body["data"]["object"] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_invoice_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -468,7 +468,7 @@ RSpec.describe Webhookdb::Replicator::StripeInvoiceV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_invoice_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -660,7 +660,7 @@ RSpec.describe Webhookdb::Replicator::StripeInvoiceV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_invoice_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_payout_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_payout_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripePayoutV1, :db do
-  it_behaves_like "a replicator", "stripe_payout_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -49,7 +49,7 @@ RSpec.describe Webhookdb::Replicator::StripePayoutV1, :db do
     end
     let(:expected_data) { body["data"]["object"] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_payout_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -141,7 +141,7 @@ RSpec.describe Webhookdb::Replicator::StripePayoutV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_payout_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -224,7 +224,7 @@ RSpec.describe Webhookdb::Replicator::StripePayoutV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_payout_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_price_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_price_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripePriceV1, :db do
-  it_behaves_like "a replicator", "stripe_price_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -50,7 +50,7 @@ RSpec.describe Webhookdb::Replicator::StripePriceV1, :db do
     end
     let(:expected_data) { body["data"]["object"] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_price_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -144,7 +144,7 @@ RSpec.describe Webhookdb::Replicator::StripePriceV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_price_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -228,7 +228,7 @@ RSpec.describe Webhookdb::Replicator::StripePriceV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_price_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_product_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_product_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripeProductV1, :db do
-  it_behaves_like "a replicator", "stripe_product_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -43,7 +43,7 @@ RSpec.describe Webhookdb::Replicator::StripeProductV1, :db do
     end
     let(:expected_data) { body["data"]["object"] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_product_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -123,7 +123,7 @@ RSpec.describe Webhookdb::Replicator::StripeProductV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_product_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -200,7 +200,7 @@ RSpec.describe Webhookdb::Replicator::StripeProductV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_product_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_refund_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_refund_v1_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Webhookdb::Replicator::StripeRefundV1, :db do
   let(:sint) { Webhookdb::Fixtures.service_integration.create(service_name: "stripe_refund_v1") }
   let(:svc) { Webhookdb::Replicator.create(sint) }
 
-  it_behaves_like "a replicator", "stripe_refund_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -197,7 +197,7 @@ RSpec.describe Webhookdb::Replicator::StripeRefundV1, :db do
     end
     let(:expected_data) { body["data"]["object"]["refunds"]["data"][0] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_refund_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -579,7 +579,7 @@ RSpec.describe Webhookdb::Replicator::StripeRefundV1, :db do
     let(:expected_new_data) { new_body["data"]["object"]["refunds"]["data"][0] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_refund_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_in_envelope_json) { refund_event_from_charge }
     let(:resource_json) { refund_event_from_charge["data"]["object"]["refunds"]["data"][0] }
     let(:refund_event_from_charge) do
@@ -772,7 +772,7 @@ RSpec.describe Webhookdb::Replicator::StripeRefundV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_refund_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_in_envelope_json) { refund_event }
     let(:resource_json) { refund_event["data"]["object"] }
     let(:refund_event) do
@@ -865,7 +865,7 @@ RSpec.describe Webhookdb::Replicator::StripeRefundV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_refund_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_subscription_item_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_subscription_item_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripeSubscriptionItemV1, :db do
-  it_behaves_like "a replicator", "stripe_subscription_item_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -270,7 +270,7 @@ RSpec.describe Webhookdb::Replicator::StripeSubscriptionItemV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_subscription_item_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/stripe_subscription_v1_spec.rb
+++ b/spec/webhookdb/replicator/stripe_subscription_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::StripeSubscriptionV1, :db do
-  it_behaves_like "a replicator", "stripe_subscription_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -113,7 +113,7 @@ RSpec.describe Webhookdb::Replicator::StripeSubscriptionV1, :db do
     end
     let(:expected_data) { body["data"]["object"] }
   end
-  it_behaves_like "a replicator that prevents overwriting new data with old", "stripe_subscription_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -333,7 +333,7 @@ RSpec.describe Webhookdb::Replicator::StripeSubscriptionV1, :db do
     let(:expected_new_data) { new_body["data"]["object"] }
   end
 
-  it_behaves_like "a replicator that deals with resources and wrapped events", "stripe_subscription_v1" do
+  it_behaves_like "a replicator that deals with resources and wrapped events" do
     let(:resource_json) { resource_in_envelope_json.dig("data", "object") }
     let(:resource_in_envelope_json) do
       JSON.parse(<<~J)
@@ -480,7 +480,7 @@ RSpec.describe Webhookdb::Replicator::StripeSubscriptionV1, :db do
           to_return(status: 403, body: "", headers: {})
     end
   end
-  it_behaves_like "a replicator that can backfill", "stripe_subscription_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/transistor_episode_stats_v1_spec.rb
+++ b/spec/webhookdb/replicator/transistor_episode_stats_v1_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Webhookdb::Replicator::TransistorEpisodeStatsV1, :db do
     end
   end
 
-  it_behaves_like "a replicator", "transistor_episode_stats_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -42,12 +42,12 @@ RSpec.describe Webhookdb::Replicator::TransistorEpisodeStatsV1, :db do
     end
   end
 
-  it_behaves_like "a replicator dependent on another", "transistor_episode_stats_v1",
+  it_behaves_like "a replicator dependent on another",
                   "transistor_episode_v1" do
     let(:no_dependencies_message) { "This integration requires Transistor Episodes to sync" }
   end
 
-  it_behaves_like "a replicator that can backfill", "transistor_episode_stats_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/transistor_episode_v1_spec.rb
+++ b/spec/webhookdb/replicator/transistor_episode_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::TransistorEpisodeV1, :db do
-  it_behaves_like "a replicator", "transistor_episode_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -50,7 +50,7 @@ RSpec.describe Webhookdb::Replicator::TransistorEpisodeV1, :db do
     let(:expected_data) { body["data"] }
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "transistor_episode_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -176,7 +176,7 @@ RSpec.describe Webhookdb::Replicator::TransistorEpisodeV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "transistor_episode_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {
@@ -333,7 +333,7 @@ RSpec.describe Webhookdb::Replicator::TransistorEpisodeV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "transistor_episode_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:page1_response) do
       <<~R
         {
@@ -457,7 +457,7 @@ RSpec.describe Webhookdb::Replicator::TransistorEpisodeV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that uses enrichments", "transistor_episode_v1", stores_enrichment_column: false do
+  it_behaves_like "a replicator that uses enrichments", stores_enrichment_column: false do
     let(:body) do
       JSON.parse(<<~JSON)
         {

--- a/spec/webhookdb/replicator/transistor_show_v1_spec.rb
+++ b/spec/webhookdb/replicator/transistor_show_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::TransistorShowV1, :db do
-  it_behaves_like "a replicator", "transistor_show_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -65,7 +65,7 @@ RSpec.describe Webhookdb::Replicator::TransistorShowV1, :db do
     let(:expected_data) { body["data"] }
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "transistor_show_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -221,7 +221,7 @@ RSpec.describe Webhookdb::Replicator::TransistorShowV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "transistor_show_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:page1_response) do
       <<~R
         {

--- a/spec/webhookdb/replicator/twilio_sms_v1_spec.rb
+++ b/spec/webhookdb/replicator/twilio_sms_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::TwilioSmsV1, :db do
-  it_behaves_like "a replicator", "twilio_sms_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -34,7 +34,7 @@ RSpec.describe Webhookdb::Replicator::TwilioSmsV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "twilio_sms_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {
@@ -146,7 +146,7 @@ RSpec.describe Webhookdb::Replicator::TwilioSmsV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill", "twilio_sms_v1" do
+  it_behaves_like "a replicator that can backfill" do
     let(:today) { Time.parse("2020-11-22T18:00:00Z") }
     let(:page1_response) do
       <<~R
@@ -302,7 +302,7 @@ RSpec.describe Webhookdb::Replicator::TwilioSmsV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that can backfill incrementally", "twilio_sms_v1" do
+  it_behaves_like "a replicator that can backfill incrementally" do
     let(:today) { Time.parse("2020-11-22T18:00:00Z") }
     let(:page1_response) do
       <<~R

--- a/spec/webhookdb/replicator/url_recorder_v1_spec.rb
+++ b/spec/webhookdb/replicator/url_recorder_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::UrlRecorderV1, :db do
-  it_behaves_like "a replicator", "url_recorder_v1" do
+  it_behaves_like "a replicator", supports_row_diff: false do
     let(:request_path) { "/foo" }
     let(:request_method) { "GET" }
     let(:request_headers) { {"Accept" => "*"} }
@@ -26,7 +26,6 @@ RSpec.describe Webhookdb::Replicator::UrlRecorderV1, :db do
     end
 
     let(:body) { {"x" => 1} }
-    let(:supports_row_diff) { false }
     let(:expected_row) do
       include(
         unique_id: 1,

--- a/spec/webhookdb/replicator/webhookdb_customer_v1_spec.rb
+++ b/spec/webhookdb/replicator/webhookdb_customer_v1_spec.rb
@@ -3,7 +3,7 @@
 require "support/shared_examples_for_replicators"
 
 RSpec.describe Webhookdb::Replicator::WebhookdbCustomerV1, :db do
-  it_behaves_like "a replicator", "webhookdb_customer_v1" do
+  it_behaves_like "a replicator" do
     let(:body) do
       JSON.parse(<<~J)
         {
@@ -16,7 +16,7 @@ RSpec.describe Webhookdb::Replicator::WebhookdbCustomerV1, :db do
     end
   end
 
-  it_behaves_like "a replicator that prevents overwriting new data with old", "webhookdb_customer_v1" do
+  it_behaves_like "a replicator that prevents overwriting new data with old" do
     let(:old_body) do
       JSON.parse(<<~J)
         {


### PR DESCRIPTION
Rather than `it_behaves_like "a replicator", "service_name_v1"`, you can just do `it_behaves_like "a replicator"`,
The service name is pulled from `described_class.descriptor.name`.

This is less code, and also prevents using the wrong service name, which can too-easily (and did) happen.

Also overhaul how `support_row_diff` is configured- use an argument like

	it_behaves_like "a replicator", support_row_diff: false do

rather than

	it_behaves_like "a replicator" do
		let(:support_row_diff) { false }

This better reflects the fact that this is static, not dynamic, and allows us to entirely exclude tests rather than no-op them.

NOTE: This is potentially a breaking change
for some tests of custom integrations.
