### PR TITLE
Fix front signalwire message edge case

### DIFF
--- a/lib/webhookdb/organization.rb
+++ b/lib/webhookdb/organization.rb
@@ -456,6 +456,17 @@ class Webhookdb::Organization < Webhookdb::Postgres::Model(:organizations)
     return self.add_all_membership(opts)
   end
 
+  def close(confirm:)
+    raise Webhookdb::InvalidPrecondition, "confirm must be true to close the org" unless confirm
+    unless self.service_integrations_dataset.empty?
+      msg = "Organization[#{self.key} cannot close with active service integrations"
+      raise Webhookdb::InvalidPrecondition, msg
+    end
+    memberships = self.all_memberships_dataset.all.each(&:destroy)
+    self.destroy
+    return [self, memberships]
+  end
+
   # SUBSCRIPTION PERMISSIONS
 
   def active_subscription?

--- a/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
+++ b/spec/webhookdb/replicator/front_signalwire_message_channel_app_v1_spec.rb
@@ -580,9 +580,25 @@ RSpec.describe Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1, :db do
       end
       expect(req).to have_been_made
       expect(svc.admin_dataset(&:all)).to contain_exactly(
-        include(external_id: "both_id", signalwire_sid: "swid1", front_message_id: "fmid"),
-        include(external_id: "sw_id_only", signalwire_sid: "swid2", front_message_id: "FMID2"),
-        include(external_id: "OLD_sw_id_only", signalwire_sid: "OLD_swid2", front_message_id: "skipped_due_to_age"),
+        include(
+          external_id: "both_id",
+          signalwire_sid: "swid1",
+          front_message_id: "fmid",
+          data: be_empty,
+        ),
+        # Use not_includde to verify the data/row splat workaround works.
+        include(
+          external_id: "sw_id_only",
+          signalwire_sid: "swid2",
+          front_message_id: "FMID2",
+          data: not_include("pk"),
+        ),
+        include(
+          external_id: "OLD_sw_id_only",
+          signalwire_sid: "OLD_swid2",
+          front_message_id: "skipped_due_to_age",
+          data: not_include("pk"),
+        ),
       )
     end
 


### PR DESCRIPTION
Add a helper for closing an organization

---

Fix front signalwire message edge case

We were replacing the `data` column with the full row,
which was giving us a `data` shape we weren't expecting,
causing errors during backfill (on receipt of a signalwire message).

This would only manifest under certain conditions which kicked off
a backfill in this situation, I'm not entirely sure why.
But it was definitely a bug which needed to be fixed.
