### PR TITLE
Fix encoding error when sending developer alerts

### DIFF
--- a/data/messages/templates/specs/with_fields.email.liquid
+++ b/data/messages/templates/specs/with_fields.email.liquid
@@ -1,0 +1,6 @@
+{% expose subject %}subject with multiple fields{% endexpose %}
+a: {{ a }}
+b: {{ b }}
+c: {{ c }}
+d: {{ d }}
+e: {{ e }}

--- a/lib/webhookdb/messages/specs.rb
+++ b/lib/webhookdb/messages/specs.rb
@@ -27,6 +27,22 @@ module Webhookdb::Messages::Testers
     end
   end
 
+  class WithFields < Base
+    # noinspection RubyInstanceVariableNamingConvention
+    def initialize(a: nil, b: nil, c: nil, d: nil, e: nil)
+      @a = a
+      @b = b
+      @c = c
+      @d = d
+      @e = e
+      super()
+    end
+
+    def liquid_drops
+      return super.merge(a: @a, b: @b, c: @c, d: @d, e: @e)
+    end
+  end
+
   class Nonextant < Base
   end
 


### PR DESCRIPTION
If there is a mixed character encoding of string values in a liquid drop, such as when handling user-supplied values, force all strings into UTF-8.

This is needed because the way Ruby does encoding coercion when parsing input which does not declare an encoding, such as a file or especially an HTTP response. Ruby will:
- Use ASCII if the values fit into 7 bits
- Use ASCII-8BIT if the values fit into 8 bits (128 to 255)
- Otherwise, use UTF-8.

The actual rules are more complex, but this is common enough.

While ASCII encoding can be used as UTF-8, ASCII-8BIT cannot. So adding `(ascii-8bit string) + (utf-8 string)` will error with an `Encoding::CompatibilityError`.

Instead, if we see a series of liquid drop string values with different encodings, force them all to be UTF-8. This can result in some unexpected behavior,
but it should be fine, since you'd only see it with unexpected input (all valid inputs should be UTF-8).
