### PR TITLE
ICalendar: Handle missing TZID, and add feed metrics

### DIFF
--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -487,7 +487,11 @@ The secret to use for signing is:
     def _ical_entry_from_ruby(r, entry, is_date)
       return {"v" => r.strftime("%Y%m%d")} if is_date
       return {"v" => r.strftime("%Y%m%dT%H%M%SZ")} if r.zone == "UTC"
-      return {"v" => r.strftime("%Y%m%dT%H%M%S"), "TZID" => entry.fetch("TZID")}
+      tzid = entry["TZID"]
+      return {"v" => r.strftime("%Y%m%dT%H%M%S"), "TZID" => tzid} if tzid
+      value = entry.fetch("v")
+      return {"v" => value} if value.end_with?("Z")
+      raise "Cannot create ical entry from: #{r}, #{entry}, is_date: #{is_date}"
     end
 
     def _icecube_rule_from_ical(ical)


### PR DESCRIPTION
ICalendar: Add sync time, event count, feed size

Some ICalendar feeds are very large, which cause performance problems.
Large feed files take a while to download,
and feeds with many events take a while to upsert
(a big feed with few recurring events can still be fast,
and a small feed with many recurring events can be slow).

Start tracking stats about the feed when we sync,
so we can use it to dynamically schedule-
small/fast feeds can be reprocessed often and slower feeds
can be processed less often.

---

ICalendar: Handle missing tzid, this is a new thing we're seeing.
