### PR TITLE
Quality-of-life fixes

### DIFF
--- a/db/migrations/046_indices.rb
+++ b/db/migrations/046_indices.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:service_integrations) do
+      add_index :depends_on_id
+      add_index :service_name
+    end
+
+    alter_table(:message_deliveries) do
+      add_index :soft_deleted_at
+    end
+  end
+end

--- a/lib/webhookdb/organization/alerting.rb
+++ b/lib/webhookdb/organization/alerting.rb
@@ -23,7 +23,10 @@ class Webhookdb::Organization::Alerting
 
   # Dispatch the message template to administrators of the org.
   # @param message_template [Webhookdb::Message::Template]
-  def dispatch_alert(message_template, separate_connection: false)
+  # @param separate_connection [true,false] If true, send the alert on a separate connection.
+  #   See +Webhookdb::Idempotency+. Defaults to true since this is an alert method and we
+  #   don't want it to error accidentally, if the code is called from an unexpected situation.
+  def dispatch_alert(message_template, separate_connection: true)
     unless message_template.respond_to?(:signature)
       raise Webhookdb::InvalidPrecondition,
             "message template #{message_template.template_name} must define a #signature method, " \

--- a/lib/webhookdb/replicator/base.rb
+++ b/lib/webhookdb/replicator/base.rb
@@ -651,6 +651,9 @@ for information on how to refresh data.)
   # @param [Webhookdb::Replicator::WebhookRequest] request
   def upsert_webhook(request, **kw)
     return self._upsert_webhook(request, **kw)
+  rescue Amigo::Retry::Error
+    # Do not log this since it's expected/handled by Amigo
+    raise
   rescue StandardError => e
     self.logger.error("upsert_webhook_error", request: request.as_json, error: e)
     raise

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -285,8 +285,9 @@ The secret to use for signing is:
         response_status = nil
     end
     raise e if response_status.nil?
+    loggable_body = response_body && response_body[..256]
     self.logger.warn("icalendar_fetch_error",
-                     response_body:, response_status:, request_url:, calendar_external_id:,)
+                     response_body: loggable_body, response_status:, request_url:, calendar_external_id:,)
     message = Webhookdb::Messages::ErrorIcalendarFetch.new(
       self.service_integration,
       calendar_external_id,

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -295,7 +295,7 @@ The secret to use for signing is:
       request_url:,
       request_method: "GET",
     )
-    self.service_integration.organization.alerting.dispatch_alert(message)
+    self.service_integration.organization.alerting.dispatch_alert(message, separate_connection: false)
   end
 
   def _retryable_client_error?(e, request_url:)

--- a/lib/webhookdb/replicator/signalwire_message_v1.rb
+++ b/lib/webhookdb/replicator/signalwire_message_v1.rb
@@ -208,7 +208,7 @@ Press 'Show' next to the newly-created API token, and copy it.)
       request_url:,
       request_method:,
     )
-    self.service_integration.organization.alerting.dispatch_alert(message, separate_connection: true)
+    self.service_integration.organization.alerting.dispatch_alert(message)
     return true
   end
 end

--- a/lib/webhookdb/service.rb
+++ b/lib/webhookdb/service.rb
@@ -191,17 +191,7 @@ class Webhookdb::Service < Grape::API
     status = e.respond_to?(:status) ? e.status : 500
     error_id = SecureRandom.uuid
     error_signature = Digest::MD5.hexdigest("#{e.class}: #{e.message}")
-
-    Webhookdb::Service.logger.error "[%s] Uncaught %p in service: %s" %
-      [error_id, e.class, e.message]
-    Webhookdb::Service.logger.debug { e.backtrace.join("\n") }
-    if ENV["PRINT_API_ERROR"]
-      puts e
-      puts e.backtrace
-    end
-
     more = {error_id:, error_signature:}
-
     if Webhookdb::Service.devmode
       msg = e.message
       more[:backtrace] = e.backtrace.join("\n")
@@ -210,6 +200,12 @@ class Webhookdb::Service < Grape::API
       msg = "An internal error occurred of type #{error_signature}. Error ID: #{error_id}"
     end
     Webhookdb::Service.logger.error("api_exception", {error_id:, error_signature:}, e)
+    Webhookdb::Service.logger.debug { e.backtrace.join("\n") }
+    if ENV["PRINT_API_ERROR"]
+      puts e
+      puts e.backtrace
+    end
+
     merror!(status, msg, code: "api_error", more:)
   end
 

--- a/spec/webhookdb/replicator/fake_spec.rb
+++ b/spec/webhookdb/replicator/fake_spec.rb
@@ -708,6 +708,17 @@ or leave blank to choose the first option.
         )
       end
 
+      it "does not log Amigo errors" do
+        err = Amigo::Retry::OrDie.new(1, 1)
+        expect(fake).to receive(:_upsert_webhook).and_raise(err)
+        logs = capture_logs_from(fake.logger, level: :info, formatter: :json) do
+          expect do
+            fake.upsert_webhook(Webhookdb::Replicator::WebhookRequest.new(body: {"a" => 1}))
+          end.to raise_error(err)
+        end
+        expect(logs).to be_empty
+      end
+
       describe "" do
         before(:each) do
           sint.organization.prepare_database_connections


### PR DESCRIPTION
Add some indices, modify a query to use an index

---

Remove some excessive log messages

---

Alerting uses separate connections by default

It's dangerous to have the idempotency error when alerting.