### PR TITLE
Add a monitoring job, and do not enqueue webhooks for bot GET requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
       barnes (~> 0.0)
       bcrypt (~> 3.1)
       biz (~> 1.8)
+      browser (~> 6.0)
       clipboard (~> 1.3)
       concurrent-ruby (~> 1.2)
       down (~> 5.4)
@@ -108,6 +109,7 @@ GEM
     biz (1.8.2)
       clavius (~> 1.0)
       tzinfo
+    browser (6.0.0)
     builder (3.2.4)
     clavius (1.0.4)
     clipboard (1.3.6)

--- a/lib/webhookdb/api/service_integrations.rb
+++ b/lib/webhookdb/api/service_integrations.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "browser"
 require "grape"
 require "oj"
 

--- a/lib/webhookdb/jobs/monitor_metrics.rb
+++ b/lib/webhookdb/jobs/monitor_metrics.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "webhookdb/async/scheduled_job"
+require "webhookdb/jobs"
+
+# Log out some metrics every minute.
+class Webhookdb::Jobs::MonitorMetrics
+  extend Webhookdb::Async::ScheduledJob
+
+  cron "* * * * *" # Every 1 minute
+  splay 0
+
+  def _perform
+    opts = {}
+    max_size = 0
+    max_latency = 0
+    Sidekiq::Queue.all.each do |q|
+      size = q.size
+      latency = q.latency
+      max_size = [max_size, size].max
+      max_latency = [max_latency, latency].max
+      opts["#{q.name}_size"] = size
+      opts["#{q.name}_latency"] = latency
+    end
+    opts[:max_size] = max_size
+    opts[:max_latency] = max_latency
+    self.logger.info("metrics_monitor_queue", **opts)
+  end
+end

--- a/webhookdb.gemspec
+++ b/webhookdb.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency("barnes", "~> 0.0")
   s.add_dependency("bcrypt", "~> 3.1")
   s.add_dependency("biz", "~> 1.8")
+  s.add_dependency("browser", "~> 6.0")
   s.add_dependency("clipboard", "~> 1.3")
   s.add_dependency("concurrent-ruby", "~> 1.2")
   s.add_dependency("down", "~> 5.4")


### PR DESCRIPTION
Do not enqueue webhooks for bot GET requests

Pasting a link in Slack for a replicator that does not validate auth
results in invalid webhooks being processed.
This is very rare, because almost everything uses auth info,
but it's not true of every integration/API.

---

Add a monitor for sidekiq queue size and latency
