### PR TITLE
Add `Webhookdb::ExceptionCarrier`

### DIFF
--- a/lib/webhookdb.rb
+++ b/lib/webhookdb.rb
@@ -144,6 +144,22 @@ module Webhookdb
 
   class LockFailed < WebhookdbError; end
 
+  # This exception is rescued in the API and returned to the caller via +merror!+.
+  # This is mostly used in synchronously-processed replicators that need to return
+  # very specific types of errors during processing.
+  # This is very rare.
+  class ExceptionCarrier < WebhookdbError
+    attr_reader :status, :code, :more, :headers
+
+    def initialize(status, message, code: nil, more: {}, headers: {})
+      super(message)
+      @status = status
+      @code = code
+      @more = more
+      @headers = headers
+    end
+  end
+
   ### Generate a key for the specified Sequel model +instance+ and
   ### any additional +parts+ that can be used for idempotent requests.
   def self.idempotency_key(instance, *parts)

--- a/lib/webhookdb.rb
+++ b/lib/webhookdb.rb
@@ -35,27 +35,33 @@ module Webhookdb
   include Appydays::Configurable
   extend Webhookdb::MethodUtilities
 
+  # Base class for all WebhookDB errors.
+  class WebhookdbError < StandardError; end
+
+  # Class for errors that usually should not be rescued from.
+  class ProgrammingError < WebhookdbError; end
+
   # Error raised when we cannot take an action
   # because some condition has not been set up right.
-  class InvalidPrecondition < StandardError; end
+  class InvalidPrecondition < ProgrammingError; end
 
   # Error raised when, after we take an action,
   # something we expect to have changed has not changed.
-  class InvalidPostcondition < StandardError; end
+  class InvalidPostcondition < ProgrammingError; end
 
   # Some invariant has been violated, which we never expect to see.
-  class InvariantViolation < StandardError; end
+  class InvariantViolation < ProgrammingError; end
 
   # Error raised when a customer gives us some invalid input.
   # Allows the library to raise the error with the message,
   # and is caught automatically by the service as a 400.
-  class InvalidInput < StandardError; end
+  class InvalidInput < WebhookdbError; end
 
   # Raised when an organization's database cannot be modified.
-  class DatabaseLocked < StandardError; end
+  class DatabaseLocked < WebhookdbError; end
 
   # Used in various places that need to short-circuit code in regression mode.
-  class RegressionModeSkip < StandardError; end
+  class RegressionModeSkip < WebhookdbError; end
 
   APPLICATION_NAME = "Webhookdb"
   RACK_ENV = Appydays::Configurable.fetch_env(["RACK_ENV", "RUBY_ENV"], "development")
@@ -136,7 +142,7 @@ module Webhookdb
   # :section: Errors
   #
 
-  class LockFailed < StandardError; end
+  class LockFailed < WebhookdbError; end
 
   ### Generate a key for the specified Sequel model +instance+ and
   ### any additional +parts+ that can be used for idempotent requests.

--- a/lib/webhookdb/aggregate_result.rb
+++ b/lib/webhookdb/aggregate_result.rb
@@ -18,7 +18,7 @@ require "webhookdb" unless defined?(Webhookdb)
 #   end
 #   return ag.finish
 #
-class Webhookdb::AggregateResult < StandardError
+class Webhookdb::AggregateResult < Webhookdb::WebhookdbError
   attr_reader :successes, :failures, :errors
 
   def initialize(existing=nil)

--- a/lib/webhookdb/connection_cache.rb
+++ b/lib/webhookdb/connection_cache.rb
@@ -45,7 +45,7 @@ class Webhookdb::ConnectionCache
   extend Webhookdb::MethodUtilities
   include Webhookdb::Dbutil
 
-  class ReentranceError < StandardError; end
+  class ReentranceError < Webhookdb::ProgrammingError; end
 
   configurable(:connection_cache) do
     # If this many seconds has elapsed since the last connecton was borrowed,

--- a/lib/webhookdb/console.rb
+++ b/lib/webhookdb/console.rb
@@ -5,7 +5,7 @@ require "webhookdb"
 module Webhookdb::Console
   extend Webhookdb::MethodUtilities
 
-  class Error < StandardError; end
+  class Error < Webhookdb::WebhookdbError; end
 
   class UnsafeOperation < Error; end
 

--- a/lib/webhookdb/customer.rb
+++ b/lib/webhookdb/customer.rb
@@ -12,8 +12,8 @@ class Webhookdb::Customer < Webhookdb::Postgres::Model(:customers)
   include Appydays::Configurable
   include Webhookdb::Admin::Linked
 
-  class InvalidPassword < StandardError; end
-  class SignupDisabled < StandardError; end
+  class InvalidPassword < Webhookdb::WebhookdbError; end
+  class SignupDisabled < Webhookdb::WebhookdbError; end
 
   configurable(:customer) do
     setting :signup_email_allowlist, ["*"], convert: ->(s) { s.split }

--- a/lib/webhookdb/customer/reset_code.rb
+++ b/lib/webhookdb/customer/reset_code.rb
@@ -6,7 +6,7 @@ require "webhookdb/postgres"
 require "webhookdb/customer"
 
 class Webhookdb::Customer::ResetCode < Webhookdb::Postgres::Model(:customer_reset_codes)
-  class Unusable < StandardError; end
+  class Unusable < Webhookdb::WebhookdbError; end
 
   TOKEN_LENGTH = 6
 

--- a/lib/webhookdb/db_adapter.rb
+++ b/lib/webhookdb/db_adapter.rb
@@ -3,7 +3,7 @@
 class Webhookdb::DBAdapter
   require "webhookdb/db_adapter/column_types"
 
-  class UnsupportedAdapter < StandardError; end
+  class UnsupportedAdapter < Webhookdb::ProgrammingError; end
 
   VALID_IDENTIFIER = /^[a-zA-Z][a-zA-Z\d_ ]*$/
   INVALID_IDENTIFIER_PROMPT =

--- a/lib/webhookdb/http.rb
+++ b/lib/webhookdb/http.rb
@@ -11,7 +11,7 @@ module Webhookdb::Http
   end
 
   # Error raised when some API has rate limited us.
-  class BaseError < StandardError; end
+  class BaseError < Webhookdb::WebhookdbError; end
 
   class Error < BaseError
     attr_reader :response, :body, :uri, :status, :http_method

--- a/lib/webhookdb/message.rb
+++ b/lib/webhookdb/message.rb
@@ -156,9 +156,9 @@ module Webhookdb::Message
     Webhookdb::Message::Delivery.unsent.each(&:send!)
   end
 
-  class InvalidTransportError < StandardError; end
+  class InvalidTransportError < Webhookdb::ProgrammingError; end
 
-  class MissingTemplateError < StandardError; end
+  class MissingTemplateError < Webhookdb::ProgrammingError; end
 
   # Presents a homogeneous interface for a given 'to' value (email vs. customer, for example).
   # .to will always be a plain object, and .customer will be a +Webhookdb::Customer+ if present.

--- a/lib/webhookdb/message/transport.rb
+++ b/lib/webhookdb/message/transport.rb
@@ -5,7 +5,7 @@ require "webhookdb/message"
 class Webhookdb::Message::Transport
   extend Webhookdb::MethodUtilities
 
-  class Error < StandardError; end
+  class Error < Webhookdb::WebhookdbError; end
   class UndeliverableRecipient < Error; end
 
   singleton_attr_reader :transports

--- a/lib/webhookdb/organization.rb
+++ b/lib/webhookdb/organization.rb
@@ -9,7 +9,7 @@ require "webhookdb/jobs/replication_migration"
 class Webhookdb::Organization < Webhookdb::Postgres::Model(:organizations)
   include Webhookdb::Admin::Linked
 
-  class SchemaMigrationError < StandardError; end
+  class SchemaMigrationError < Webhookdb::ProgrammingError; end
 
   plugin :timestamps
   plugin :soft_deletes

--- a/lib/webhookdb/organization/database_migration.rb
+++ b/lib/webhookdb/organization/database_migration.rb
@@ -4,7 +4,7 @@ class Webhookdb::Organization::DatabaseMigration < Webhookdb::Postgres::Model(:o
   include Webhookdb::Dbutil
 
   class MigrationInProgress < Webhookdb::DatabaseLocked; end
-  class MigrationAlreadyFinished < StandardError; end
+  class MigrationAlreadyFinished < Webhookdb::WebhookdbError; end
 
   plugin :timestamps
   plugin :text_searchable, terms: [:organization, :started_by]

--- a/lib/webhookdb/organization/db_builder.rb
+++ b/lib/webhookdb/organization/db_builder.rb
@@ -22,7 +22,7 @@ class Webhookdb::Organization::DbBuilder
   include Webhookdb::Dbutil
   extend Webhookdb::MethodUtilities
 
-  class IsolatedOperationError < StandardError; end
+  class IsolatedOperationError < Webhookdb::ProgrammingError; end
 
   DATABASE = "database"
   SCHEMA = "schema"

--- a/lib/webhookdb/postgres.rb
+++ b/lib/webhookdb/postgres.rb
@@ -13,7 +13,7 @@ module Webhookdb::Postgres
   extend Webhookdb::MethodUtilities
   include Appydays::Loggable
 
-  class InTransaction < StandardError; end
+  class InTransaction < Webhookdb::ProgrammingError; end
 
   singleton_attr_accessor :unsafe_skip_transaction_check
   @unsafe_skip_transaction_check = false

--- a/lib/webhookdb/replicator.rb
+++ b/lib/webhookdb/replicator.rb
@@ -15,11 +15,11 @@ class Webhookdb::Replicator
   PLUGIN_DIR = Pathname(__FILE__).dirname + PLUGIN_DIRNAME
 
   # Raised when there is no service registered for a name.
-  class Invalid < StandardError; end
+  class Invalid < Webhookdb::WebhookdbError; end
 
   # Raised when credentials to interact with a service are not set up.
   # Usually this is due to a missing dependency.
-  class CredentialsMissing < StandardError; end
+  class CredentialsMissing < Webhookdb::WebhookdbError; end
 
   # Statically describe a replicator.
   class Descriptor < Webhookdb::TypedStruct

--- a/lib/webhookdb/service.rb
+++ b/lib/webhookdb/service.rb
@@ -163,6 +163,10 @@ class Webhookdb::Service < Grape::API
     error!(e.message, 405)
   end
 
+  rescue_from Webhookdb::ExceptionCarrier do |e|
+    merror!(e.status, e.message, code: e.code, more: e.more, headers: e.headers)
+  end
+
   rescue_from Webhookdb::LockFailed do |_e|
     merror!(
       409,

--- a/lib/webhookdb/service/view_api.rb
+++ b/lib/webhookdb/service/view_api.rb
@@ -3,7 +3,7 @@
 # Mixin for Grape API endpoints that use HTML rendering.
 # This isn't tested well enough.
 module Webhookdb::Service::ViewApi
-  class FormError < StandardError
+  class FormError < Webhookdb::WebhookdbError
     attr_reader :status
 
     def initialize(msg, status=400)

--- a/lib/webhookdb/sync_target.rb
+++ b/lib/webhookdb/sync_target.rb
@@ -21,9 +21,9 @@ class Webhookdb::SyncTarget < Webhookdb::Postgres::Model(:sync_targets)
   include Appydays::Configurable
   include Webhookdb::Dbutil
 
-  class Deleted < StandardError; end
-  class InvalidConnection < StandardError; end
-  class SyncInProgress < StandardError; end
+  class Deleted < Webhookdb::WebhookdbError; end
+  class InvalidConnection < Webhookdb::WebhookdbError; end
+  class SyncInProgress < Webhookdb::WebhookdbError; end
 
   # Advisory locks for sync targets use this as the first int, and the id as the second.
   ADVISORY_LOCK_KEYSPACE = 2_000_000_000


### PR DESCRIPTION
Add ExceptionCarrier exceptions

ExceptionCarrier is rescued in the API and
returned to the caller via +merror!+.
This is mostly used in synchronously-processed
replicators that need to return
very specific types of errors during processing.
This is very rare.

---

Use a base class for all WHDB errors

Webhookdb::WebhookdbError replaces uses standarderror as the base.

Webhookdb::ProgrammingError indicates errors that are due to
programming and are generally not caught.
