### PR TITLE
Improve icalendar performance (avoid writes during vacuum, compare data)

### DIFF
--- a/lib/webhookdb/organization/db_builder.rb
+++ b/lib/webhookdb/organization/db_builder.rb
@@ -282,7 +282,7 @@ class Webhookdb::Organization::DbBuilder
   # (and we probably don't want the admin role trying to delete itself).
   def remove_related_database
     return if @org.admin_connection_url_raw.blank?
-    superuser_str = self._find_superuser_url_str
+    superuser_str = self.find_superuser_url_str
     # Cannot use conn cache since we may be removing ourselves
     borrow_conn(superuser_str) do |conn|
       case self.class.isolation_mode
@@ -309,7 +309,8 @@ class Webhookdb::Organization::DbBuilder
     end
   end
 
-  protected def _find_superuser_url_str
+  # Find the superuser connection URL for the organization's database.
+  def find_superuser_url_str
     admin_url = URI.parse(@org.admin_connection_url_raw)
     superuser_str = self.class.available_server_urls.find do |sstr|
       surl = URI.parse(sstr)
@@ -325,7 +326,7 @@ class Webhookdb::Organization::DbBuilder
   def roll_connection_credentials
     raise IsolatedOperationError, "cannot roll credentials without a user isolation mode" unless
       self.class.isolate?(USER)
-    superuser_uri = URI(self._find_superuser_url_str)
+    superuser_uri = URI(self.find_superuser_url_str)
     orig_readonly_user = URI(@org.readonly_connection_url_raw).user
     ro_user = self.randident("ro")
     ro_pwd = self.randident

--- a/spec/webhookdb/replicator/icalendar_event_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_event_v1_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Webhookdb::Replicator::IcalendarEventV1, :db do
         :pk,
         calendar_external_id: "123",
         compound_identity: "123-79396C44-9EA7-4EF0-A99F-5EFCE7764CFE",
-        data: include("DTEND"),
+        data: include("DTEND").and(not_include("row_updated_at")),
         start_at: match_time("2020-02-20 17:00:00Z"),
         uid: "79396C44-9EA7-4EF0-A99F-5EFCE7764CFE",
       )


### PR DESCRIPTION
Icalendar event conditional update uses data

last_modified_at is set to either the LAST-MODIFIED value,
OR the row_updated_at timestamp.
Many feeds do not have LAST-MODIFIED, so all rows get updated.
Compare against data to avoid the constant writes.
JSONB != operations are very fast,
so this should not be any real performance issue.

---

Add `avoid_writes?`, icalendar backs off

Some tables, like icalendar, necessarily go through a high level
of churn. This causes more frequent vacuums than other tables.
Do not sync calendars if the table is being vacuumed.