### PR TITLE
Icalendar: Improve queue management

### DIFF
--- a/lib/webhookdb/organization.rb
+++ b/lib/webhookdb/organization.rb
@@ -513,6 +513,57 @@ class Webhookdb::Organization < Webhookdb::Postgres::Model(:organizations)
 
   # @!attribute service_integrations
   #   @return [Array<Webhookdb::ServiceIntegration>]
+
+  # @!attribute created_at
+  #   @return [Time,nil]
+
+  # @!attribute updated_at
+  #   @return [Time,nil]
+
+  # @!attribute soft_deleted_at
+  #   @return [Time,nil]
+
+  # @!attribute name
+  #   @return [String]
+
+  # @!attribute key
+  #   @return [String]
+
+  # @!attribute billing_email
+  #   @return [String]
+
+  # @!attribute stripe_customer_id
+  #   @return [String]
+
+  # @!attribute readonly_connection_url_raw
+  #   @return [String]
+
+  # @!attribute admin_connection_url_raw
+  #   @return [String]
+
+  # @!attribute public_host
+  #   @return [String]
+
+  # @!attribute cloudflare_dns_record_json
+  #   @return [Hash]
+
+  # @!attribute replication_schema
+  #   @return [String]
+
+  # @!attribute job_semaphore_size
+  #   @return [Integer]
+
+  # @!attribute minimum_sync_seconds
+  #   @return [Integer]
+
+  # @!attribute sync_target_timeout
+  #   @return [Integer]
+
+  # @!attribute max_query_rows
+  #   @return [Integer]
+
+  # @!attribute priority_backfill
+  #   @return [true,false]
 end
 
 require "webhookdb/organization/alerting"

--- a/spec/webhookdb/api/service_integrations_spec.rb
+++ b/spec/webhookdb/api/service_integrations_spec.rb
@@ -222,12 +222,11 @@ RSpec.describe Webhookdb::API::ServiceIntegrations,
     end
   end
 
-  describe "POST /v1/service_integrations/:opaque_id" do
+  describe "POST /v1/service_integrations/:opaque_id", sidekiq: :fake do
     before(:each) do
       # this endpoint should be unauthed, so we will test it unauthed
       logout
       _ = sint
-      Sidekiq::Testing.fake! # We don't want to process the jobs
     end
 
     it "runs the ProcessWebhook job with the data for the webhook", :async do

--- a/spec/webhookdb/async/jobs_spec.rb
+++ b/spec/webhookdb/async/jobs_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe "webhookdb async jobs", :async, :db, :do_not_defer_events, :no_tr
         )
       end
       Webhookdb::Jobs::IcalendarEnqueueSyncs.new.perform(true)
-      expect(Sidekiq).to have_queue.consisting_of(
+      expect(Sidekiq).to have_queue("netout").consisting_of(
         job_hash(Webhookdb::Jobs::IcalendarSync, args: [sint.id, "abc"], at: be > Time.now.to_f),
         job_hash(Webhookdb::Jobs::IcalendarSync, args: [sint.id, "xyz"], at: be > Time.now.to_f),
       )

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
             ),
           )
         end
-        expect(Sidekiq).to have_queue.consisting_of(
+        expect(Sidekiq).to have_queue("netout").consisting_of(
           job_hash(Webhookdb::Jobs::IcalendarSync, args: [sint.id, "456"]),
         )
       end
@@ -142,7 +142,7 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
             ),
           )
         end
-        expect(Sidekiq).to have_queue.consisting_of(
+        expect(Sidekiq).to have_queue("netout").consisting_of(
           job_hash(Webhookdb::Jobs::IcalendarSync, args: [sint.id, "456"]),
         )
       end

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -1558,6 +1558,27 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
         end
       end
     end
+
+    it "skips the job if the row has recently been synced, unless force: true" do
+      body = <<~ICAL
+        BEGIN:VEVENT
+        SUMMARY:Abraham Lincoln
+        UID:c7614cff-3549-4a00-9152-d25cc1fe077d
+        DTSTART:20080212
+        DTEND:20080213
+        DTSTAMP:20150421T141403
+        END:VEVENT
+      ICAL
+      row = insert_calendar_row(ics_url: "https://feed.me", external_id: "abc", last_synced_at: 2.hours.ago)
+      svc.sync_row(row)
+      expect(event_svc.admin_dataset(&:all)).to be_empty
+
+      req = stub_request(:get, "https://feed.me").
+        and_return(status: 200, headers: {"Content-Type" => "text/calendar"}, body:)
+      svc.sync_row(row, force: true)
+      expect(req).to have_been_made
+      expect(event_svc.admin_dataset(&:all)).to have_length(1)
+    end
   end
 
   # Based on https://github.com/icalendar/icalendar/blob/main/spec/parser_spec.rb


### PR DESCRIPTION
ICalendar: Do not sync recently synced rows

We were enqueing rows needing sync every 30 minutes,
but scheduling them out over several hours (sync_period).
This could result in a single row being synced multiple times
over the sync_period, especially if the queue is backed up.

Instead, early-out when running sync_row,
if the row has been synced within the sync period.

---

Use netout queue, semaphore job for ical sync

It was happening on the default queue,
which was wrong, and we really should be using the job semaphore
as well.

---

Fix flaky spec, needed to clear sidekiq jobs

---

Add YARD annotations to organizations