### PR TITLE
Re-implement stale row deleter for massive tables

### DIFF
--- a/lib/webhookdb/icalendar.rb
+++ b/lib/webhookdb/icalendar.rb
@@ -20,7 +20,9 @@ module Webhookdb::Icalendar
     # (ie, no thundering herd every 8 hours), but it is still a good idea to sync as infrequently as possible.
     setting :sync_period_hours, 6
 
-    # Cancelled events that were cancelled this long ago are deleted from the database.
-    setting :stale_cancelled_event_threshold_days, 35
+    # Cancelled events that were last updated this long ago are deleted from the database.
+    setting :stale_cancelled_event_threshold_days, 20
+    # The stale row deleter job will look for rows this far before the threshold.
+    setting :stale_cancelled_event_lookback_days, 3
   end
 end

--- a/lib/webhookdb/jobs/stale_row_deleter.rb
+++ b/lib/webhookdb/jobs/stale_row_deleter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "webhookdb/async/job"
+
+# Run the +stale_row_deleter+ for each service integration
+# which match the given where/exclude clauses.
+# This is generally used to delete old stale rows in the backend
+# (by passing initial: true) when a new stale row deleter is deployed.
+class Webhookdb::Jobs::StaleRowDeleter
+  extend Webhookdb::Async::Job
+
+  def perform(opts={})
+    opts = opts.deep_symbolize_keys
+    opts[:where] ||= {}
+    opts[:exclude] ||= {}
+    opts[:initial] ||= false
+    ds = Webhookdb::ServiceIntegration.dataset
+    ds = ds.where(opts[:where]) if opts[:where]
+    ds = ds.exclude(opts[:exclude]) if opts[:exclude]
+    ds.each do |sint|
+      self.with_log_tags(sint.log_tags) do
+        d = sint.replicator.stale_row_deleter
+        opts[:initial] ? d.run_initial : d.run
+      end
+    end
+  end
+end

--- a/lib/webhookdb/replicator/icalendar_event_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_event_v1.rb
@@ -378,7 +378,7 @@ class Webhookdb::Replicator::IcalendarEventV1 < Webhookdb::Replicator::Base
   # and then deleted over time.
   class StaleRowDeleter < Webhookdb::Replicator::BaseStaleRowDeleter
     def stale_at = Webhookdb::Icalendar.stale_cancelled_event_threshold_days.days
-    def age_cutoff = (Webhookdb::Icalendar.stale_cancelled_event_threshold_days + 10).days
+    def lookback_window = Webhookdb::Icalendar.stale_cancelled_event_lookback_days.days
     def updated_at_column = :row_updated_at
     def stale_condition = {status: "CANCELLED"}
   end

--- a/spec/webhookdb/async/jobs_spec.rb
+++ b/spec/webhookdb/async/jobs_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe "webhookdb async jobs", :async, :db, :do_not_defer_events, :no_tr
       sint.replicator.admin_dataset do |ds|
         ds.insert(data: "{}", compound_identity: "new", uid: "new", row_updated_at: Time.now, status: "CANCELLED")
         ds.insert(
-          data: "{}", compound_identity: "stale", uid: "stale", row_updated_at: 40.days.ago, status: "CANCELLED",
+          data: "{}", compound_identity: "stale", uid: "stale", row_updated_at: 21.days.ago, status: "CANCELLED",
         )
       end
       Webhookdb::Jobs::IcalendarDeleteStaleCancelledEvents.new.perform(true)

--- a/spec/webhookdb/replicator/base_stale_row_deleter_spec.rb
+++ b/spec/webhookdb/replicator/base_stale_row_deleter_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+RSpec.describe Webhookdb::Replicator::BaseStaleRowDeleter, :db do
+  let(:sint) { Webhookdb::Fixtures.service_integration.create(service_name: "fake_stale_row_v1") }
+  let(:svc) { sint.replicator }
+  let(:org) { sint.organization }
+
+  before(:each) do
+    org.prepare_database_connections
+    svc.create_table
+  end
+
+  after(:each) { org.remove_related_database }
+
+  def upsert(my_id, at, textcol)
+    return svc.upsert_webhook_body({my_id:, at:, textcol:}.stringify_keys)
+  end
+
+  it "deletes stale rows" do
+    upsert("recent", 3.days.ago, "cancelled")
+    upsert("stale", 7.days.ago, "cancelled")
+    upsert("stale_not_cancelled", 7.days.ago, "confirmed")
+    upsert("too_old", 12.days.ago, "cancelled")
+    svc.stale_row_deleter.run
+    expect(svc.admin_dataset { |ds| ds.select(:my_id).all }).to contain_exactly(
+      include(my_id: "recent"),
+      include(my_id: "stale_not_cancelled"),
+      include(my_id: "too_old"),
+    )
+  end
+
+  it "can use a nil age cutoff" do
+    upsert("recent", 3.days.ago, "cancelled")
+    upsert("stale", 7.days.ago, "cancelled")
+    upsert("old", 12.days.ago, "cancelled")
+    svc.stale_row_deleter.run_initial
+    expect(svc.admin_dataset(&:all)).to contain_exactly(
+      include(my_id: "recent"),
+    )
+  end
+
+  it "deletes in chunks (implementation test)" do
+    # Create a bunch of rows at the same time to ensure they all get deleted as chunks,
+    # to test the 'delete in chunks' behavior.
+    upsert("recent", 3.days.ago, "cancelled")
+    Array.new(43) { upsert("stale", 7.days.ago, "cancelled") }
+    upsert("not_cancelled", 7.days.ago, "confirmed")
+    svc.stale_row_deleter.run
+    expect(svc.admin_dataset(&:all)).to contain_exactly(
+      include(my_id: "recent"),
+      include(my_id: "not_cancelled"),
+    )
+  end
+
+  it "walks the row delete interval in small increments (implementation test)" do
+    # Create a spread of rows across and beyond the full time range and make sure they all get deleted,
+    # to check the 'incremental time range walking' behavior.
+    Timecop.freeze("2020-10-30") do
+      at = 4.days.ago.utc
+      cutoff = 11.days.ago.utc
+      until at < cutoff
+        upsert("e-#{at.iso8601}", at, "cancelled")
+        at -= 4.hours
+      end
+      svc.stale_row_deleter.run
+    end
+    expect(svc.admin_dataset(&:all)).to contain_exactly(
+      include(my_id: "e-2020-10-26T07:00:00Z"),
+      include(my_id: "e-2020-10-26T03:00:00Z"),
+      include(my_id: "e-2020-10-25T23:00:00Z"),
+      include(my_id: "e-2020-10-25T19:00:00Z"),
+      include(my_id: "e-2020-10-25T15:00:00Z"),
+      include(my_id: "e-2020-10-25T11:00:00Z"),
+      include(my_id: "e-2020-10-20T03:00:00Z"),
+      include(my_id: "e-2020-10-19T23:00:00Z"),
+      include(my_id: "e-2020-10-19T19:00:00Z"),
+      include(my_id: "e-2020-10-19T15:00:00Z"),
+      include(my_id: "e-2020-10-19T11:00:00Z"),
+      include(my_id: "e-2020-10-19T07:00:00Z"),
+    )
+  end
+
+  it "disables and re-enables vacuuming" do
+    logs = capture_logs_from(Webhookdb.logger, level: :debug, formatter: :json) do
+      svc.stale_row_deleter.run
+    end
+    expect(logs).to have_a_line_matching(
+      /"query":"ALTER TABLE public\.#{sint.table_name} SET \(autovacuum_enabled='off'\)"/,
+    )
+    expect(logs).to have_a_line_matching(
+      /"query":"ALTER TABLE public\.#{sint.table_name} SET \(autovacuum_enabled='on'\)"/,
+    )
+  end
+
+  it "errors if the delete would cause a sequential scan" do
+    svc.admin_dataset { |ds| ds.db << "DROP INDEX #{sint.opaque_id}_at_idx" }
+    upsert("e1", 7.days.ago, "cancelled")
+    expect do
+      svc.stale_row_deleter.run
+    end.to raise_error(Webhookdb::InvariantViolation, /would have caused a sequential scan/)
+  end
+
+  it "handles no rows (to delete, or at all)" do
+    expect do
+      svc.stale_row_deleter.run
+      svc.stale_row_deleter.run_initial
+      upsert("e1", Time.now, "confirmed")
+      svc.stale_row_deleter.run
+      svc.stale_row_deleter.run_initial
+    end.to_not raise_error
+  end
+end

--- a/spec/webhookdb/replicator/base_stale_row_deleter_spec.rb
+++ b/spec/webhookdb/replicator/base_stale_row_deleter_spec.rb
@@ -59,24 +59,24 @@ RSpec.describe Webhookdb::Replicator::BaseStaleRowDeleter, :db do
       at = 4.days.ago.utc
       cutoff = 11.days.ago.utc
       until at < cutoff
-        upsert("e-#{at.iso8601}", at, "cancelled")
+        upsert("e-#{at.strftime('%Y-%m-%dT%H')}", at, "cancelled")
         at -= 4.hours
       end
       svc.stale_row_deleter.run
     end
     expect(svc.admin_dataset(&:all)).to contain_exactly(
-      include(my_id: "e-2020-10-26T07:00:00Z"),
-      include(my_id: "e-2020-10-26T03:00:00Z"),
-      include(my_id: "e-2020-10-25T23:00:00Z"),
-      include(my_id: "e-2020-10-25T19:00:00Z"),
-      include(my_id: "e-2020-10-25T15:00:00Z"),
-      include(my_id: "e-2020-10-25T11:00:00Z"),
-      include(my_id: "e-2020-10-20T03:00:00Z"),
-      include(my_id: "e-2020-10-19T23:00:00Z"),
-      include(my_id: "e-2020-10-19T19:00:00Z"),
-      include(my_id: "e-2020-10-19T15:00:00Z"),
-      include(my_id: "e-2020-10-19T11:00:00Z"),
-      include(my_id: "e-2020-10-19T07:00:00Z"),
+      include(my_id: "e-2020-10-26T07"),
+      include(my_id: "e-2020-10-26T03"),
+      include(my_id: "e-2020-10-25T23"),
+      include(my_id: "e-2020-10-25T19"),
+      include(my_id: "e-2020-10-25T15"),
+      include(my_id: "e-2020-10-25T11"),
+      include(my_id: "e-2020-10-20T03"),
+      include(my_id: "e-2020-10-19T23"),
+      include(my_id: "e-2020-10-19T19"),
+      include(my_id: "e-2020-10-19T15"),
+      include(my_id: "e-2020-10-19T11"),
+      include(my_id: "e-2020-10-19T07"),
     )
   end
 

--- a/spec/webhookdb/replicator/icalendar_event_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_event_v1_spec.rb
@@ -366,35 +366,14 @@ RSpec.describe Webhookdb::Replicator::IcalendarEventV1, :db do
 
     it "deletes stale cancelled events" do
       upsert("recent", 3.days.ago)
-      upsert("stale", 40.days.ago)
-      upsert("stale_not_cancelled", 40.days.ago, status: "CONFIRMED")
+      upsert("stale", 21.days.ago)
+      upsert("stale_not_cancelled", 21.days.ago, status: "CONFIRMED")
       upsert("too_old", 100.days.ago)
       svc.stale_row_deleter.run
       expect(svc.admin_dataset { |ds| ds.select(:uid).all }).to contain_exactly(
         include(uid: "recent"),
         include(uid: "stale_not_cancelled"),
         include(uid: "too_old"),
-      )
-    end
-
-    it "can use a nil age cutoff" do
-      upsert("recent", 3.days.ago)
-      upsert("stale", 40.days.ago)
-      upsert("old", 100.days.ago)
-      svc.stale_row_deleter.run_initial
-      expect(svc.admin_dataset(&:all)).to contain_exactly(
-        include(uid: "recent"),
-      )
-    end
-
-    it "deletes in chunks" do
-      upsert("recent", 3.days.ago)
-      Array.new(100) { upsert("stale", 40.days.ago) }
-      upsert("not_cancelled", 40.days.ago, status: "CONFIRMED")
-      svc.stale_row_deleter.run
-      expect(svc.admin_dataset(&:all)).to contain_exactly(
-        include(uid: "recent"),
-        include(uid: "not_cancelled"),
       )
     end
   end


### PR DESCRIPTION
Running the stale row deleter on massive (billion-row?) tables could cause problems.
This uses a new algorithm to issue a series of small deletes by walking the delete window in hour chunks,
and avoiding a sequential scan and also allowing faster re-deletes because we don't have to walk a larger index space for each chunk.