### PR TITLE
Add stats to sync targets

### DIFF
--- a/db/migrations/048_sync_stats.rb
+++ b/db/migrations/048_sync_stats.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:sync_targets) do
+      add_column :sync_stats, :jsonb, null: false, default: "[]"
+    end
+  end
+end

--- a/lib/webhookdb/concurrent.rb
+++ b/lib/webhookdb/concurrent.rb
@@ -49,7 +49,7 @@ module Webhookdb::Concurrent
   # you can use a +Concurrent::ThreadPoolExecutor+. This pool will not allow the enqueing of more work
   # while the queue is full.
   class ParallelizedPool < Pool
-    def initialize(queue_size, timeout:, threads: nil)
+    def initialize(queue_size, timeout: nil, threads: nil)
       super()
       threads ||= queue_size
       @timeout = timeout
@@ -80,8 +80,8 @@ module Webhookdb::Concurrent
 
     def post(&task)
       raise @exception if @exception
-      ok = @queue.push(task)
-      raise Timeout if ok.nil?
+      added = @queue.push(task, timeout: @timeout)
+      raise Timeout, "waited #{@timeout} to add to the queue" if added.nil?
       return true
     end
 

--- a/lib/webhookdb/sync_target.rb
+++ b/lib/webhookdb/sync_target.rb
@@ -436,10 +436,7 @@ class Webhookdb::SyncTarget < Webhookdb::Postgres::Model(:sync_targets)
       @threadpool = if self.sync_target.parallelism.zero?
                       Webhookdb::Concurrent::SerialPool.new
         else
-          Webhookdb::Concurrent::ParallelizedPool.new(
-            self.sync_target.parallelism,
-            timeout: self.sync_target.service_integration.organization.sync_target_timeout,
-          )
+          Webhookdb::Concurrent::ParallelizedPool.new(self.sync_target.parallelism)
       end
       @mutex = Thread::Mutex.new
     end


### PR DESCRIPTION
Useful little addition to see how sync targets are running by tracking some stats internally, without requiring a monitoring service.
