### PR TITLE
Disallow _remote_key_column index:true

### DIFF
--- a/lib/webhookdb/replicator/base.rb
+++ b/lib/webhookdb/replicator/base.rb
@@ -406,7 +406,12 @@ for information on how to refresh data.)
 
   # @return [Webhookdb::DBAdapter::Column]
   def remote_key_column
-    return self._remote_key_column.to_dbadapter(unique: true, nullable: false)
+    c = self._remote_key_column
+    if c.index?
+      msg = "_remote_key_column index:true should not be set, since it automatically gets a unique index"
+      Kernel.warn msg
+    end
+    return c.to_dbadapter(unique: true, nullable: false, index: false)
   end
 
   # @return [Webhookdb::DBAdapter::Column]
@@ -464,6 +469,9 @@ for information on how to refresh data.)
 
   # Each integration needs a single remote key, like the Shopify order id for shopify orders,
   # or sid for Twilio resources. This column must be unique for the table, like a primary key.
+  #
+  # NOTE: Do not set index:true. The remote key column always must be unique,
+  # so it gets a unique index automatically.
   #
   # @abstract
   # @return [Webhookdb::Replicator::Column]

--- a/lib/webhookdb/replicator/email_octopus_contact_v1.rb
+++ b/lib/webhookdb/replicator/email_octopus_contact_v1.rb
@@ -29,7 +29,6 @@ class Webhookdb::Replicator::EmailOctopusContactV1 < Webhookdb::Replicator::Base
       :compound_identity,
       TEXT,
       data_key: "<compound key, see converter>",
-      index: true,
       optional: true,
       converter: CONV_REMOTE_KEY,
     )

--- a/lib/webhookdb/replicator/icalendar_event_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_event_v1.rb
@@ -116,7 +116,6 @@ class Webhookdb::Replicator::IcalendarEventV1 < Webhookdb::Replicator::Base
       :compound_identity,
       TEXT,
       data_key: "<compound key, see converter>",
-      index: true,
       converter: CONV_REMOTE_KEY,
       optional: true, # This is done via the converter, data_key never exists
     )

--- a/lib/webhookdb/replicator/transistor_episode_stats_v1.rb
+++ b/lib/webhookdb/replicator/transistor_episode_stats_v1.rb
@@ -40,7 +40,6 @@ class Webhookdb::Replicator::TransistorEpisodeStatsV1 < Webhookdb::Replicator::B
       :compound_identity,
       TEXT,
       data_key: "<compound key, see converter>",
-      index: true,
       optional: true,
       converter: CONV_REMOTE_KEY,
     )

--- a/spec/webhookdb/replicator/base_spec.rb
+++ b/spec/webhookdb/replicator/base_spec.rb
@@ -92,6 +92,17 @@ RSpec.describe Webhookdb::Replicator::Base, :db do
     end
   end
 
+  describe "remote_key_column" do
+    it "warns if index:true is specified" do
+      r = Webhookdb::Fixtures.service_integration.create.replicator
+      expect(r).to receive(:_remote_key_column).
+        and_return(Webhookdb::Replicator::Column.new(:my_id, :text, index: true))
+      expect(Kernel).to receive(:warn).with(/_remote_key_column index:true/)
+      c = r.remote_key_column
+      expect(c).to_not be_index
+    end
+  end
+
   describe "_prepare_for_insert" do
     svc_cls = Class.new(described_class) do
       def _remote_key_column

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -1773,10 +1773,12 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
 
       it "returns an array of calendars" do
         parsed = all_events
-        # Because we project '5 years' into the future, we can end up with 36 or 37 events
+        # Because we project '5 years' into the future, we can end up with 36 or more events
         # (3102AFB1-1FE8-49A1-BBB2-20965DFD44C9-30 is the extra event).
-        # Use Timecop.travel('2024-08-10') to see 36 and Timecop.travel('2024-08-16') to see 37.
-        expect(parsed).to have_length(be_between(36, 37))
+        # Use Timecop.travel('2024-08-10') to see 36,
+        # Timecop.travel('2024-08-16') to see 37,
+        # Timecop.travel('2024-12-03') to see 38.
+        expect(parsed).to have_length(be_between(36, 38))
         expect(parsed).to include(
           hash_including("DTSTART" => {"v" => "20220514"}),
           hash_including("DTSTART" => {"v" => "20220814"}),


### PR DESCRIPTION
This ends up creating a duplicate index.
We already get something like
`repl_v1_external_id_key" UNIQUE CONSTRAINT, btree (external_id)`. Using index:true also gives us
`svi_78217ral2fkp0vh2vusozghxz_external_id_idx btree (external_id)`

Set `index:false` explicitly
(to support any replicators out in the wild)
and warn if any replicator uses index:true.
