### PR TITLE
Front/Signalwire: Support multiple recipients

### DIFF
--- a/lib/webhookdb/replicator/base.rb
+++ b/lib/webhookdb/replicator/base.rb
@@ -62,7 +62,7 @@ class Webhookdb::Replicator::Base
   # and the arguments used to upsert it (arguments to upsert_webhook),
   # and should return the body string to respond back with.
   #
-  # @param [Hash] upserted
+  # @param [Hash,Array] upserted
   # @param [Webhookdb::Replicator::WebhookRequest] request
   # @return [String]
   def synchronous_processing_response_body(upserted:, request:)

--- a/lib/webhookdb/replicator/base.rb
+++ b/lib/webhookdb/replicator/base.rb
@@ -649,6 +649,7 @@ for information on how to refresh data.)
   # like when we have to take different action based on a request method.
   #
   # @param body [Hash]
+  # @return [Array,Hash] Inserted rows, or array of inserted rows if many.
   def upsert_webhook_body(body, **kw)
     return self.upsert_webhook(Webhookdb::Replicator::WebhookRequest.new(body:), **kw)
   end
@@ -657,6 +658,7 @@ for information on how to refresh data.)
   # NOT a Rack::Request.
   #
   # @param [Webhookdb::Replicator::WebhookRequest] request
+  # @return [Array,Hash] Inserted rows, or array of inserted rows if many.
   def upsert_webhook(request, **kw)
     return self._upsert_webhook(request, **kw)
   rescue Amigo::Retry::Error
@@ -672,19 +674,11 @@ for information on how to refresh data.)
   #
   # @param request [Webhookdb::Replicator::WebhookRequest]
   # @param upsert [Boolean] If false, just return what would be upserted.
+  # @return [Array,Hash] Inserted rows, or array of inserted rows if many.
   def _upsert_webhook(request, upsert: true)
     resource_or_list, event = self._resource_and_event(request)
     return nil if resource_or_list.nil?
     if resource_or_list.is_a?(Array)
-      unless upsert
-        # In the future, we could make it possible to support
-        # multiple rows with upsert:false, but since upsert:false
-        # assumes we use the returned value, and an array of resources
-        # changes the return type from a hash to an array,
-        # this seems risky and hard to program against.
-        msg = "resource_and_event cannot return multiple events if upsert is false"
-        raise Webhookdb::InvalidPostcondition, msg
-      end
       unless event.nil?
         msg = "resource_and_event cannot return an array of resources with a non-nil event"
         raise Webhookdb::InvalidPostcondition, msg

--- a/spec/webhookdb/api/install_spec.rb
+++ b/spec/webhookdb/api/install_spec.rb
@@ -594,7 +594,7 @@ RSpec.describe Webhookdb::API::Install, :db, reset_configuration: Webhookdb::Cus
           expect(last_response).to have_status(200)
           expect(last_response).to have_json_body.that_includes(
             type: "success",
-            external_id: "msg_55c8c149",
+            external_id: "msg_55c8c149-+13334445555",
             external_conversation_id: "+13334445555",
           )
         end

--- a/spec/webhookdb/replicator/fake_spec.rb
+++ b/spec/webhookdb/replicator/fake_spec.rb
@@ -712,7 +712,7 @@ or leave blank to choose the first option.
 
       it "noops if resource_and_event returns nil" do
         Webhookdb::Replicator::Fake.resource_and_event_hook = ->(_) { [nil, nil] }
-        got = fake.upsert_webhook_body({"my_id" => "abc", "at" => "2024-01-15T12:00:00Z"}, upsert: false)
+        got = fake.upsert_webhook_body({"my_id" => "abc", "at" => "2024-01-15T12:00:00Z"})
         expect(got).to be_nil
         expect(fake.readonly_dataset(&:all)).to be_empty
       end
@@ -767,15 +767,6 @@ or leave blank to choose the first option.
             include(my_id: "def"),
             include(my_id: "xyz"),
           )
-        end
-
-        it "errors if upsert is false" do
-          Webhookdb::Replicator::Fake.resource_and_event_hook = lambda { |_|
-            [[], nil]
-          }
-          expect do
-            fake.upsert_webhook_body({"my_id" => "abc", "at" => Time.now.to_s}, upsert: false)
-          end.to raise_error(Webhookdb::InvalidPostcondition, /multiple events if upsert is false/)
         end
 
         it "errors if the returned event is not nil" do

--- a/spec/webhookdb/replicator/fake_spec.rb
+++ b/spec/webhookdb/replicator/fake_spec.rb
@@ -686,14 +686,43 @@ or leave blank to choose the first option.
     end
 
     describe "upsert_webhook" do
+      Webhookdb::SpecHelpers::Whdb.setup_upsert_webhook_example(self)
+
+      before(:each) do
+        sint.organization.prepare_database_connections
+        fake.create_table
+        Webhookdb::Replicator::Fake.reset
+      end
+
+      after(:each) do
+        sint.organization.remove_related_database
+      end
+
+      it "returns the upserted value" do
+        got = fake.upsert_webhook_body({"my_id" => "abc", "at" => "2024-01-15T12:00:00Z"})
+        expect(got).to include(my_id: "abc", at: match_time("2024-01-15T12:00:00Z"))
+        expect(fake.readonly_dataset(&:all)).to contain_exactly(include(my_id: "abc"))
+      end
+
+      it "returns nil and does no insert if upsert is false" do
+        got = fake.upsert_webhook_body({"my_id" => "abc", "at" => "2024-01-15T12:00:00Z"}, upsert: false)
+        expect(got).to include(my_id: "abc", at: match_time("2024-01-15T12:00:00Z"))
+        expect(fake.readonly_dataset(&:all)).to be_empty
+      end
+
+      it "noops if resource_and_event returns nil" do
+        Webhookdb::Replicator::Fake.resource_and_event_hook = ->(_) { [nil, nil] }
+        got = fake.upsert_webhook_body({"my_id" => "abc", "at" => "2024-01-15T12:00:00Z"}, upsert: false)
+        expect(got).to be_nil
+        expect(fake.readonly_dataset(&:all)).to be_empty
+      end
+
       it "logs errors" do
         err = RuntimeError.new("hi")
         expect(fake).to receive(:_upsert_webhook).and_raise(err)
         logs = capture_logs_from(fake.logger, level: :info, formatter: :json) do
           expect do
-            fake.upsert_webhook(Webhookdb::Replicator::WebhookRequest.new(
-                                  body: {"a" => 1}, headers: {"X" => "1"}, path: "/hi", method: "POST",
-                                ))
+            upsert_webhook(fake, body: {"a" => 1}, headers: {"X" => "1"}, path: "/hi", method: "POST")
           end.to raise_error(err)
         end
         expect(logs).to contain_exactly(
@@ -713,28 +742,49 @@ or leave blank to choose the first option.
         expect(fake).to receive(:_upsert_webhook).and_raise(err)
         logs = capture_logs_from(fake.logger, level: :info, formatter: :json) do
           expect do
-            fake.upsert_webhook(Webhookdb::Replicator::WebhookRequest.new(body: {"a" => 1}))
+            upsert_webhook(fake, body: {"a" => 1})
           end.to raise_error(err)
         end
         expect(logs).to be_empty
       end
 
-      describe "" do
-        before(:each) do
-          sint.organization.prepare_database_connections
+      it "strips null unicode codepoints from JSON" do
+        # See \u0000 in base.rb for more info
+        fake.upsert_webhook_body({"my_id" => "abc", "at" => Time.now.to_s, "has_u0" => "b\u0000\u00004\u0000\\u0000 u"})
+        expect(fake.readonly_dataset(&:all)).to contain_exactly(
+          include(data: hash_including("has_u0" => "b4\\u0000 u")),
+        )
+      end
+
+      describe "when the _resource_and_event returns an array" do
+        it "upserts multiple rows" do
+          Webhookdb::Replicator::Fake.resource_and_event_hook = lambda { |r|
+            [[r.body.merge("my_id" => "def"), r.body.merge("my_id" => "xyz")], nil]
+          }
+          got = fake.upsert_webhook_body({"my_id" => "abc", "at" => Time.now.to_s})
+          expect(got).to be_an(Array).and(have_length(2))
+          expect(fake.readonly_dataset(&:all)).to contain_exactly(
+            include(my_id: "def"),
+            include(my_id: "xyz"),
+          )
         end
 
-        after(:each) do
-          sint.organization.remove_related_database
+        it "errors if upsert is false" do
+          Webhookdb::Replicator::Fake.resource_and_event_hook = lambda { |_|
+            [[], nil]
+          }
+          expect do
+            fake.upsert_webhook_body({"my_id" => "abc", "at" => Time.now.to_s}, upsert: false)
+          end.to raise_error(Webhookdb::InvalidPostcondition, /multiple events if upsert is false/)
         end
 
-        it "strips null unicode codepoints from JSON" do
-          fake.create_table
-          # See \u0000 in base.rb for more info
-          fake.upsert_webhook_body({"my_id" => "abc", "at" => Time.now.to_s, "has_u0" => "b\u0000\u00004\u0000\\u0000 u"})
-          fake.readonly_dataset do |ds|
-            expect(ds.first).to include(data: hash_including("has_u0" => "b4\\u0000 u"))
-          end
+        it "errors if the returned event is not nil" do
+          Webhookdb::Replicator::Fake.resource_and_event_hook = lambda { |_|
+            [[], {}]
+          }
+          expect do
+            fake.upsert_webhook_body({"my_id" => "abc", "at" => Time.now.to_s})
+          end.to raise_error(Webhookdb::InvalidPostcondition, /array of resources with a non-nil event/)
         end
       end
     end


### PR DESCRIPTION
Front/Signalwire: Support multiple recipients

We were inserting a front/signalwire channel message only for
the first recipient, so multi-message blasts did not work.

Instead, insert a row for each recipient.

---

Upsert multiple rows for one call

`_resource_and_event` can now return an array of resources
which are each inserted individually.
This preserves current semantics around upserting,
but allows replicators to take one 'row' and derive
many from it.

Note that this is only possible to use when upserting,
and when the event part of resource_and_event is nil.

In the future, we could make it possible to support
multiple rows with upsert:false, but since upsert:false
assumes we use the returned value, and an array of resources
changes the return type from a hash to an array,
this seems risky and hard to program against.