### PR TITLE
ICalendar: Skip unchanged feeds, better scheduling, page size

### DIFF
--- a/lib/webhookdb/icalendar.rb
+++ b/lib/webhookdb/icalendar.rb
@@ -13,12 +13,17 @@ module Webhookdb::Icalendar
     # Do not store events older then this when syncing recurring events.
     # Many icalendar feeds are misconfigured and this prevents enumerating 2000+ years of recurrence.
     setting :oldest_recurring_event, "2000-01-01", convert: ->(s) { Date.parse(s) }
-    # Sync icalendar calendars only this often.
-    # Most services only update every day or so. Assume it takes 5s to sync each feed (request, parse, upsert).
-    # If you have 10,000 feeds, that is 50,000 seconds, or almost 14 hours of processing time,
-    # or two threads for 7 hours. The resyncs are spread out across the sync period
-    # (ie, no thundering herd every 8 hours), but it is still a good idea to sync as infrequently as possible.
-    setting :sync_period_hours, 10
+    # Calendars feeds are considered 'fresh' if they have been synced this long ago or less.
+    # Most services only update every day or so.
+    # Assume it takes 5s to sync each feed (request, parse, upsert).
+    # If you have 10,000 feeds, that is 50,000 seconds,
+    # or almost 14 hours of processing time, or two threads for 7 hours.
+    setting :sync_period_hours, 6
+    # When stale feeds are scheduled for a resync,
+    # 'smear' them along this duration. Using 0 would immediately enqueue syncs of all stale feeds,
+    # which could saturate the job server. The number here means that feeds will be refreshed between every
+    # +sync_period_hours+ and +sync_period_hours+ + +sync_period_splay_hours+.
+    setting :sync_period_splay_hours, 1
     # Number of threads for the 'precheck' threadpool, used when enqueing icalendar sync jobs.
     # Since the precheck process uses many threads, but each check is resource-light and not latency-sensitive,
     # we use a shared threadpool for it.

--- a/lib/webhookdb/icalendar.rb
+++ b/lib/webhookdb/icalendar.rb
@@ -19,6 +19,10 @@ module Webhookdb::Icalendar
     # or two threads for 7 hours. The resyncs are spread out across the sync period
     # (ie, no thundering herd every 8 hours), but it is still a good idea to sync as infrequently as possible.
     setting :sync_period_hours, 10
+    # Number of threads for the 'precheck' threadpool, used when enqueing icalendar sync jobs.
+    # Since the precheck process uses many threads, but each check is resource-light and not latency-sensitive,
+    # we use a shared threadpool for it.
+    setting :precheck_feed_change_pool_size, 100
 
     # Cancelled events that were last updated this long ago are deleted from the database.
     setting :stale_cancelled_event_threshold_days, 20

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
@@ -46,22 +46,32 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
     # rather than the whole period.
     max_projected_out_seconds = Webhookdb::Icalendar.sync_period_hours.hours.to_i / 4
     total_count = 0
+    threadpool = Concurrent::CachedThreadPool.new(
+      name: "ical-precheck",
+      max_queue: Webhookdb::Icalendar.precheck_feed_change_pool_size,
+      fallback_policy: :caller_runs,
+    )
     Webhookdb::ServiceIntegration.dataset.where_each(service_name: "icalendar_calendar_v1") do |sint|
       sint_count = 0
-      sint.replicator.admin_dataset do |ds|
-        sint.replicator.rows_needing_sync(ds).select(:external_id, :last_synced_at).each do |row|
-          self.with_log_tags(sint.log_tags) do
-            calendar_external_id = row.fetch(:external_id)
-            perform_in = rand(1..max_projected_out_seconds)
-            enqueued_job_id = Webhookdb::Jobs::IcalendarSync.perform_in(perform_in, sint.id, calendar_external_id)
-            self.logger.debug("enqueued_icalendar_sync", calendar_external_id:, enqueued_job_id:, perform_in:)
-            sint_count += 1
+      self.with_log_tags(sint.log_tags) do
+        sint.replicator.admin_dataset do |ds|
+          sint.replicator.rows_needing_sync(ds).select(:external_id, :ics_url, :last_fetch_context).each do |row|
+            threadpool.post do
+              break unless sint.replicator.feed_changed?(row)
+              calendar_external_id = row.fetch(:external_id)
+              perform_in = rand(1..max_projected_out_seconds)
+              enqueued_job_id = Webhookdb::Jobs::IcalendarSync.perform_in(perform_in, sint.id, calendar_external_id)
+              self.logger.debug("enqueued_icalendar_sync", calendar_external_id:, enqueued_job_id:, perform_in:)
+              sint_count += 1
+            end
           end
         end
       end
       total_count += sint_count
       self.set_job_tags("#{sint.organization.key}_#{sint.table_name}" => sint_count)
     end
+    threadpool.shutdown
+    threadpool.wait_for_termination
     self.set_job_tags(total_enqueued: total_count)
   end
 end

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
@@ -11,21 +11,18 @@ require "webhookdb/jobs"
 # and especially avoid saturating workers with syncs.
 # We also have to handle workers running behind, the app being slow, etc.
 #
-# - This job runs every 60 minutes.
+# - This job runs every 30 minutes.
 # - It finds rows never synced,
 #   or haven't been synced in 8 hours (see +Webhookdb::Icalendar.sync_period_hours+
 #   for the actual value, we'll assume 8 hours for this doc).
-# - Enqueue a row sync sync job for between 1 second and 60 minutes from now.
+# - Enqueue a row sync sync job for between 1 second and 60 minutes from now
+#   (see +Webhookdb::Icalendar.sync_period_splay_hours+ for actual upper bound value).
 # - When the sync job runs, if the row has been synced less than 8 hours ago, the job noops.
 #
-# In the best case scenario, all the enqueued rows are synced in the 60 minutes
-# since the job ran last, and none are found.
-#
-# In the worse scenarios, many of the calendar rows didn't get processed in time,
-# and show up on the next run.
-# In this case, the same row could be enqueued multiple times,
-# but will only run once, because the actual sync job will noop
-# if the row is recently synced.
+# This design will lead to the same calendar being enqueued for a sync multiple times
+# (for a splay of 1 hour, and running this job every 30 minutes, about half the jobs in the queue will be duplicate).
+# This isn't a problem however, since the first sync will run but the duplicates will noop
+# since the row will be seen as recently synced.
 #
 # Importantly, if there is a thundering herd situation,
 # because there is a massive traunch of rows that need to be synced,
@@ -38,13 +35,11 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
   extend Webhookdb::Async::ScheduledJob
 
   # See docs for explanation of why we run this often.
-  cron "*/60 * * * *"
+  cron "*/30 * * * *"
   splay 30
 
   def _perform
-    # See job doc for why we project out to 1/4 of the sync period,
-    # rather than the whole period.
-    max_projected_out_seconds = Webhookdb::Icalendar.sync_period_hours.hours.to_i / 4
+    max_projected_out_seconds = Webhookdb::Icalendar.sync_period_splay_hours.hours.to_i
     total_count = 0
     threadpool = Concurrent::CachedThreadPool.new(
       name: "ical-precheck",
@@ -54,10 +49,15 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
     Webhookdb::ServiceIntegration.dataset.where_each(service_name: "icalendar_calendar_v1") do |sint|
       sint_count = 0
       self.with_log_tags(sint.log_tags) do
-        sint.replicator.admin_dataset do |ds|
-          sint.replicator.rows_needing_sync(ds).select(:external_id, :ics_url, :last_fetch_context).each do |row|
+        repl = sint.replicator
+        repl.admin_dataset do |ds|
+          row_ds = repl.
+            rows_needing_sync(ds).
+            order(:pk).
+            select(:external_id, :ics_url, :last_fetch_context)
+          row_ds.each do |row|
             threadpool.post do
-              break unless sint.replicator.feed_changed?(row)
+              break unless repl.feed_changed?(row)
               calendar_external_id = row.fetch(:external_id)
               perform_in = rand(1..max_projected_out_seconds)
               enqueued_job_id = Webhookdb::Jobs::IcalendarSync.perform_in(perform_in, sint.id, calendar_external_id)

--- a/lib/webhookdb/jobs/icalendar_sync.rb
+++ b/lib/webhookdb/jobs/icalendar_sync.rb
@@ -19,11 +19,6 @@ class Webhookdb::Jobs::IcalendarSync
       self.set_job_tags(result: "icalendar_sync_row_miss")
       return
     end
-    cutoff = Time.now - Webhookdb::Icalendar.sync_period_hours.hours
-    if (last_synced = row.fetch(:last_synced_at)) && last_synced > cutoff
-      self.set_job_tags(result: "icalendar_sync_already_synced")
-      return
-    end
     self.logger.debug("icalendar_sync_start")
     sint.replicator.sync_row(row)
     self.set_job_tags(result: "icalendar_synced")

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -10,8 +10,6 @@ require "webhookdb/messages/error_icalendar_fetch"
 class Webhookdb::Replicator::IcalendarCalendarV1 < Webhookdb::Replicator::Base
   include Appydays::Loggable
 
-  class FeedUnchanged < StandardError; end
-
   RECURRENCE_PROJECTION = 5.years
 
   def documentation_url = Webhookdb::Icalendar::DOCUMENTATION_URL
@@ -79,7 +77,6 @@ The secret to use for signing is:
       col.new(:event_count, INTEGER, optional: true),
       col.new(:feed_bytes, INTEGER, optional: true),
       col.new(:last_sync_duration_ms, INTEGER, optional: true),
-      col.new(:last_fetch_context, OBJECT, optional: true),
     ]
   end
 
@@ -181,28 +178,17 @@ The secret to use for signing is:
       end
       self.with_advisory_lock(row.fetch(:pk)) do
         start = Time.now
-        begin
-          if (dep = self.find_dependent("icalendar_event_v1"))
-            if dep.replicator.avoid_writes?
-              # Check if this table is being vacuumed/etc. We use this instead of a semaphore job,
-              # since it's a better fit for icalendar, which is pre-scheduled, rather than reactive.
-              # That is, when we receive webhooks, a semaphore job gives us a more predictable rate;
-              # but icalendar rate is negotiated in advance (when enqueing jobs),
-              # and we can be more 'helpful' to something like a vacuum by not running any jobs at all.
-              self.logger.info("skip_sync_table_locked")
-              raise Amigo::Retry::Retry, 60.seconds + (rand * 10.seconds)
-            end
-            processor = self._sync_row(row, dep, now:)
+        if (dep = self.find_dependent("icalendar_event_v1"))
+          if dep.replicator.avoid_writes?
+            # Check if this table is being vacuumed/etc. We use this instead of a semaphore job,
+            # since it's a better fit for icalendar, which is pre-scheduled, rather than reactive.
+            # That is, when we receive webhooks, a semaphore job gives us a more predictable rate;
+            # but icalendar rate is negotiated in advance (when enqueing jobs),
+            # and we can be more 'helpful' to something like a vacuum by not running any jobs at all.
+            self.logger.info("skip_sync_table_locked")
+            raise Amigo::Retry::Retry, 60.seconds + (rand * 10.seconds)
           end
-        rescue FeedUnchanged
-          self.admin_dataset do |ds|
-            ds.where(pk: row.fetch(:pk)).
-              update(
-                last_synced_at: now,
-                last_fetch_context: Sequel.lit('last_fetch_context || \'{"was_cached":true}\'::jsonb'),
-              )
-          end
-          return
+          processor = self._sync_row(row, dep, now:)
         end
         self.admin_dataset do |ds|
           ds.where(pk: row.fetch(:pk)).
@@ -211,11 +197,6 @@ The secret to use for signing is:
               event_count: processor&.upserted_identities&.count,
               feed_bytes: processor&.read_bytes,
               last_sync_duration_ms: (Time.now - start).in_milliseconds,
-              last_fetch_context: {
-                "hash" => processor&.feed_hash,
-                "content_type" => processor&.headers&.fetch("Content-Type", nil),
-                "content_length" => processor&.headers&.fetch("Content-Length", nil),
-              }.to_json,
             )
         end
       end
@@ -232,9 +213,8 @@ The secret to use for signing is:
       "Accept" => "text/calendar,*/*",
     }
     begin
-      request_url = "https://calendar.google.com/calendar/ical/natalie.madaj%40warnerchappell.com/private-b66563094cebc03e4fa8b604a827b430/basic.ics"
       request_url = self._clean_ics_url(row.fetch(:ics_url))
-      dl_resp = Webhookdb::Http.chunked_download(request_url, rewindable: false, headers:)
+      io = Webhookdb::Http.chunked_download(request_url, rewindable: false, headers:)
     rescue Down::Error,
            URI::InvalidURIError,
            HTTPX::NativeResolveError,
@@ -245,12 +225,8 @@ The secret to use for signing is:
       return
     end
 
-    if (io, can_skip = self.skip_sync?(row, dl_resp)) && can_skip
-      raise FeedUnchanged
-    end
-
     upserter = Upserter.new(dep.replicator, calendar_external_id, now:)
-    processor = EventProcessor.new(io:, upserter:, headers: dl_resp.data[:headers])
+    processor = EventProcessor.new(io, upserter)
     processor.process
     # Delete all the extra replicator rows, and cancel all the rows that weren't upserted.
     dep.replicator.admin_dataset do |ds|
@@ -356,36 +332,6 @@ The secret to use for signing is:
     self.service_integration.organization.alerting.dispatch_alert(message, separate_connection: false)
   end
 
-  # Return a tuple of <StringIO, false> if the feed must be synced,
-  # or <nil, true> if the sync can be skipped.
-  # We try to avoid syncing whenever we know the feed hasn't changed.
-  # But we're also careful to avoid additional work or member where possible.
-  # So we do the following:
-  # - If we have no previous fetch context, we sync.
-  # - If the last fetch's content type and length is different from the current, we sync.
-  # - Download the bytes. If the hash of the bytes is different from what was last processed,
-  #   sync. Since this involves reading the streaming body, we must return a copy of the body (a StringIO).
-  def skip_sync?(row, dl_resp)
-    last_fetch = row[:last_fetch_context]
-    return dl_resp, false if last_fetch.nil?
-    headers = dl_resp.data[:headers] || {}
-    content_type_match = headers["Content-Type"] == last_fetch["content_type"] &&
-      headers["Content-Length"] == last_fetch["content_length"]
-    return dl_resp, false unless content_type_match
-    last_hash = last_fetch["hash"]
-    return dl_resp, false if last_hash.nil?
-
-    hash = Digest::MD5.new
-    io = StringIO.new
-    while (line = dl_resp.gets)
-      io << line
-      hash.update(line)
-    end
-    return nil, true if hash.hexdigest == last_hash
-    io.seek(0)
-    return io, false
-  end
-
   # We can hit an error while reading the error body, since it was opened as a stream.
   # Ignore those errors.
   def _safe_read_body(e)
@@ -421,12 +367,11 @@ The secret to use for signing is:
   end
 
   class EventProcessor
-    attr_reader :upserted_identities, :read_bytes, :headers
+    attr_reader :upserted_identities, :read_bytes
 
-    def initialize(io:, upserter:, headers:)
+    def initialize(io, upserter)
       @io = io
       @upserter = upserter
-      @headers = headers
       # Keep track of everything we upsert. For any rows we aren't upserting,
       # delete them if they're recurring, or cancel them if they're not recurring.
       # If doing it this way is slow, we could invert this (pull down all IDs and pop from the set).
@@ -442,10 +387,7 @@ The secret to use for signing is:
       # Keep track of the bytes we've read from the file.
       # Never trust Content-Length headers for ical feeds.
       @read_bytes = 0
-      @feed_md5 = Digest::MD5.new
     end
-
-    def feed_hash = @feed_md5.hexdigest
 
     def delete_condition
       return nil if @max_sequence_num_by_uid.empty?
@@ -661,7 +603,6 @@ The secret to use for signing is:
       in_vevent = false
       while (line = @io.gets)
         @read_bytes += line.size
-        @feed_md5.update(line)
         begin
           line.rstrip!
         rescue Encoding::CompatibilityError

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -158,7 +158,7 @@ The secret to use for signing is:
       @now = now
     end
 
-    def upsert_page_size = 500
+    def upsert_page_size = 2000
     def conditional_upsert? = true
 
     def prepare_body(body)

--- a/spec/webhookdb/async/jobs_spec.rb
+++ b/spec/webhookdb/async/jobs_spec.rb
@@ -322,23 +322,6 @@ RSpec.describe "webhookdb async jobs", :async, :db, :do_not_defer_events, :no_tr
       Webhookdb::Jobs::IcalendarSync.new.perform(sint.id, "0")
       expect(Webhookdb::Async::JobLogger.job_tags).to include(result: "icalendar_sync_row_miss")
     end
-
-    it "noops if the row has too recently been synced" do
-      last_synced_at = 2.hours.ago
-      row = sint.replicator.admin_dataset do |ds|
-        ds.insert(
-          data: "{}",
-          row_created_at: Time.now,
-          row_updated_at: Time.now,
-          external_id: "abc",
-          last_synced_at:,
-        )
-        ds.first
-      end
-      Webhookdb::Jobs::IcalendarSync.new.perform(sint.id, row.fetch(:external_id))
-      expect(sint.replicator.admin_dataset(&:first)).to include(last_synced_at: match_time(last_synced_at))
-      expect(Webhookdb::Async::JobLogger.job_tags).to include(result: "icalendar_sync_already_synced")
-    end
   end
 
   describe "IncreaseEventHandler" do

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
         event_count: nil,
         feed_bytes: nil,
         last_sync_duration_ms: nil,
-        last_fetch_context: nil,
       }
     end
   end
@@ -1631,159 +1630,6 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
       expect(req).to have_been_made
       expect(event_svc.admin_dataset(&:all)).to have_length(1)
     end
-
-    describe "caching", reset_configuration: Webhookdb::Icalendar do
-      before(:each) do
-        Webhookdb::Icalendar.sync_period_hours = 0
-      end
-
-      def run_between_syncs(row)
-        svc.admin_dataset do |ds|
-          ds.where(pk: row[:pk]).update(event_count: 100)
-        end
-      end
-
-      def assert_resynced(row)
-        r = refetch_row(row)
-        expect(r).to include(event_count: 1)
-        expect(r[:last_fetch_context]).to_not include("was_cached")
-      end
-
-      def assert_not_resynced(row)
-        r = refetch_row(row)
-        expect(r).to include(event_count: 100, last_fetch_context: hash_including("was_cached" => true))
-      end
-
-      def refetch_row(row)
-        return svc.admin_dataset { |ds| ds[pk: row.fetch(:pk)] }
-      end
-
-      it "does not sync if the content headers, and feed hash, match the previous sync" do
-        body = <<~ICAL
-          BEGIN:VCALENDAR
-          BEGIN:VEVENT
-          UID:c7614cff-3549-4a00-9152-d25cc1fe077d
-          STATUS:CONFIRMED
-          DTSTART:20080212
-          DTEND:20080213
-          END:VEVENT
-          END:VCALENDAR
-        ICAL
-        req = stub_request(:get, "https://feed.me").
-          and_return(
-            status: 200,
-            headers: {"Content-Type" => "text/calendar", "Content-Length" => body.size.to_s},
-            body:,
-          )
-        row = insert_calendar_row(ics_url: "https://feed.me", external_id: "abc")
-        svc.sync_row(row)
-        run_between_syncs(row)
-        svc.sync_row(refetch_row(row))
-        expect(req).to have_been_made.times(2)
-        assert_not_resynced(row)
-      end
-
-      it "syncs if the body is different" do
-        body1 = <<~ICAL
-          BEGIN:VCALENDAR
-          BEGIN:VEVENT
-          UID:c7614cff-3549-4a00-9152-d25cc1fe077d
-          STATUS:CONFIRMED
-          DTSTART:20080212
-          DTEND:20080213
-          END:VEVENT
-          END:VCALENDAR
-        ICAL
-        body2 = body1.gsub("c76", "ddd")
-        expect(body1.size).to eq(body2.size)
-        req = stub_request(:get, "https://feed.me").
-          and_return(
-            {
-              status: 200,
-              headers: {"Content-Type" => "text/calendar", "Content-Length" => body1.size.to_s},
-              body: body1,
-            },
-            {
-              status: 200,
-              headers: {"Content-Type" => "text/calendar", "Content-Length" => body2.size.to_s},
-              body: body2,
-            },
-          )
-
-        row = insert_calendar_row(ics_url: "https://feed.me", external_id: "abc")
-        svc.sync_row(row)
-        run_between_syncs(row)
-        svc.sync_row(refetch_row(row))
-        expect(req).to have_been_made.times(2)
-        assert_resynced(row)
-      end
-
-      it "syncs if the content type is different" do
-        body = <<~ICAL
-          BEGIN:VCALENDAR
-          BEGIN:VEVENT
-          UID:c7614cff-3549-4a00-9152-d25cc1fe077d
-          STATUS:CONFIRMED
-          DTSTART:20080212
-          DTEND:20080213
-          END:VEVENT
-          END:VCALENDAR
-        ICAL
-        req = stub_request(:get, "https://feed.me").
-          and_return(
-            {
-              status: 200,
-              headers: {"Content-Type" => "text/calendar", "Content-Length" => body.size.to_s},
-              body:,
-            },
-            {
-              status: 200,
-              headers: {"Content-Type" => "text/calendar; charset=utf-8", "Content-Length" => body.size.to_s},
-              body:,
-            },
-          )
-
-        row = insert_calendar_row(ics_url: "https://feed.me", external_id: "abc")
-        svc.sync_row(row)
-        run_between_syncs(row)
-        svc.sync_row(refetch_row(row))
-        expect(req).to have_been_made.times(2)
-        assert_resynced(row)
-      end
-
-      it "syncs if the content length is different" do
-        body = <<~ICAL
-          BEGIN:VCALENDAR
-          BEGIN:VEVENT
-          UID:c7614cff-3549-4a00-9152-d25cc1fe077d
-          STATUS:CONFIRMED
-          DTSTART:20080212
-          DTEND:20080213
-          END:VEVENT
-          END:VCALENDAR
-        ICAL
-        req = stub_request(:get, "https://feed.me").
-          and_return(
-            {
-              status: 200,
-              headers: {"Content-Type" => "text/calendar", "Content-Length" => body.size.to_s},
-              body:,
-            },
-            {
-              status: 200,
-              headers: {"Content-Type" => "text/calendar", "Content-Length" => (body.size + 1).to_s},
-              body:,
-            },
-          )
-
-        row = insert_calendar_row(ics_url: "https://feed.me", external_id: "abc")
-        svc.sync_row(row)
-        run_between_syncs(row)
-        svc.sync_row(refetch_row(row))
-        expect(req).to have_been_made.times(2)
-        assert_resynced(row)
-      end
-    end
   end
 
   # Based on https://github.com/icalendar/icalendar/blob/main/spec/parser_spec.rb
@@ -1791,17 +1637,16 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
     let(:source) { File.open(Webhookdb::SpecHelpers::TEST_DATA_DIR + "icalendar" + fn) }
     let(:replicator) { described_class.new(nil) }
     let(:upserter) { described_class::Upserter.new(replicator, "1", now: Time.now) }
-    let(:headers) { {} }
 
     def feed_events
       arr = []
-      described_class::EventProcessor.new(io: source, upserter:, headers:).each_feed_event { |a| arr << a }
+      described_class::EventProcessor.new(source, upserter).each_feed_event { |a| arr << a }
       arr
     end
 
     def all_events
       arr = []
-      pr = described_class::EventProcessor.new(io: source, upserter:, headers:)
+      pr = described_class::EventProcessor.new(source, upserter)
       pr.each_feed_event do |a|
         pr.each_projected_event(a) do |b|
           arr << b


### PR DESCRIPTION
ICalendar: Better sync enqueue scheduling

Improve and refine the algorithm around how we enqueue sync jobs
over a 'splay' period. Make the splay period configurable
as `ICALENDAR_SYNC_PERIOD_SPLAY_HOURS`
which also makes the algorithm more clear.
Feeds will be synced between every
`sync_period_hours` and `sync_period_hours + sync_period_splay_hours`.

---

Increase icalendar upsert page size

For a large client, the breakdown of events looks like this:

```
> select cnt, count(cnt) from (select width_bucket(event_count, array[500, 1000, 2000, 3000]) as cnt from icalendar_calendar_v1_aaaa) group by cnt order by cnt;
+--------+-------+
| cnt    | count |
|--------+-------|
| 0      | 14478 |
| 1      | 2649  |
| 2      | 2662  |
| 3      | 1380  |
| 4      | 2391  |
| <null> | 0     |
+--------+-------+
```

Using a larger page size means hopefully faster upserts for most calendars.
Hopefully it doesn't impact memory but we'll monitor for it.

---

Icalendar: Pre-check for feed changes

Enqueuing icalendar sync jobs now checks in advance if
the feed has likely changed. It does this in bulk using
a threadpool. It introduces extra work in the worst case
(many changes) but eliminates a lot of redundant work,
especially for more rapid sync timing.

That is, resyncing feeds every hour would be impossible at scale
due to the database churn; but if a large fraction of feeds
have not changed (which is usually the case), we can eliminate
trying to sync them for the cost of an HTTP request and minimal
processing on the Ruby side.

This checking comes at a significant clocktime penalty,
but we can largely eliminate that through parallelization,
since most of the 'work' is in HTTP requests.