### PR TITLE
Organization error handling for replication failures

### DIFF
--- a/db/migrations/049_error_handlers.rb
+++ b/db/migrations/049_error_handlers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:organization_error_handlers) do
+      primary_key :id
+      timestamptz :created_at, null: false, default: Sequel.function(:now)
+      timestamptz :updated_at
+
+      text :opaque_id, null: false, unique: true
+
+      foreign_key :organization_id, :organizations, null: false
+      foreign_key :created_by_id, :customers, null: true, on_delete: :set_null
+
+      text :url, null: false
+    end
+  end
+end

--- a/lib/webhookdb/api/error_handlers.rb
+++ b/lib/webhookdb/api/error_handlers.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "webhookdb/api"
+
+class Webhookdb::API::ErrorHandlers < Webhookdb::API::V1
+  include Webhookdb::Service::Types
+
+  CREATE_PROMPT = "What is the URL that WebhookDB should POST to when a replicator fails? " \
+                  "See #{Webhookdb::Organization::ErrorHandler::DOCS_URL} for more information:".freeze
+
+  resource :organizations do
+    route_param :org_identifier do
+      resource :error_handlers do
+        helpers do
+          def lookup!
+            org = lookup_org!
+            eh = org.error_handlers_dataset[opaque_id: params[:opaque_id].strip]
+            merror!(403, "There is no error handler with that id.") if eh.nil?
+            set_request_tags(error_handler_opaque_id: eh.opaque_id)
+            return eh
+          end
+
+          def guard_editable!(customer, org)
+            return if has_admin?(org, customer:)
+            permission_error!("You must be an org admin to modify error handlers.")
+          end
+
+          def url_valid?(u)
+            begin
+              uri = URI(u)
+            rescue URI::InvalidURIError
+              return false
+            end
+            return true if uri.scheme == "sentry"
+            return false unless uri.scheme&.start_with?("http")
+            return true
+          end
+        end
+
+        desc "Returns a list of all error handlers associated with the org."
+        get do
+          handlers = lookup_org!.error_handlers
+          message = ""
+          if handlers.empty?
+            message = "This organization doesn't have any error handlers yet.\n" \
+                      "Use `webhookdb error-handler create` to set one up."
+          end
+          present_collection handlers, with: ErrorHandlerEntity, message:
+        end
+
+        desc "Creates a new error handler."
+        params do
+          optional :url, type: TrimmedString, prompt: CREATE_PROMPT
+        end
+        post :create do
+          cust = current_customer
+          org = lookup_org!
+          guard_editable!(cust, org)
+          unless url_valid?(params[:url])
+            msg = "URL is malformed. It should be a URL like https://foo.bar/path, http://foo.bar:123, etc. " \
+                  "See #{Webhookdb::Organization::ErrorHandler::DOCS_URL} for more info."
+            merror!(400, msg)
+          end
+          eh = Webhookdb::Organization::ErrorHandler.create(
+            organization: org,
+            url: params[:url],
+            created_by: cust,
+          )
+          message = "Whenever one of your replicators errors, WebhookDB will alert the given URL. " \
+                    "See #{Webhookdb::Organization::ErrorHandler::DOCS_URL} for more information."
+          status 200
+          present eh, with: ErrorHandlerEntity, message:
+        end
+
+        route_param :opaque_id, type: String do
+          get do
+            eh = lookup!
+            status 200
+            present eh, with: ErrorHandlerEntity
+          end
+
+          post :delete do
+            customer = current_customer
+            eh = lookup!
+            guard_editable!(customer, eh.organization)
+            eh.destroy
+            status 200
+            present eh, with: ErrorHandlerEntity,
+                        message: "You have successfully deleted the error handler '#{eh.opaque_id}'."
+          end
+        end
+      end
+    end
+  end
+
+  class ErrorHandlerEntity < Webhookdb::API::BaseEntity
+    expose :opaque_id, as: :id
+    expose :url
+
+    def self.display_headers
+      return [[:id, "ID"], [:url, "Url"]]
+    end
+  end
+end

--- a/lib/webhookdb/api/system.rb
+++ b/lib/webhookdb/api/system.rb
@@ -37,6 +37,11 @@ class Webhookdb::API::System < Webhookdb::Service
     }
   end
 
+  post :sink do
+    status 204
+    body ""
+  end
+
   if ["development", "test"].include?(Webhookdb::RACK_ENV)
     resource :debug do
       resource :echo do

--- a/lib/webhookdb/apps.rb
+++ b/lib/webhookdb/apps.rb
@@ -15,6 +15,7 @@ require "webhookdb/service"
 require "webhookdb/api/auth"
 require "webhookdb/api/db"
 require "webhookdb/api/demo"
+require "webhookdb/api/error_handlers"
 require "webhookdb/api/install"
 require "webhookdb/api/me"
 require "webhookdb/api/organizations"
@@ -77,6 +78,7 @@ module Webhookdb::Apps
     mount Webhookdb::API::Auth
     mount Webhookdb::API::Db
     mount Webhookdb::API::Demo
+    mount Webhookdb::API::ErrorHandlers
     mount Webhookdb::API::Install
     mount Webhookdb::API::Me
     mount Webhookdb::API::Organizations

--- a/lib/webhookdb/fixtures/organization_error_handlers.rb
+++ b/lib/webhookdb/fixtures/organization_error_handlers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "faker"
+
+require "webhookdb/fixtures"
+
+module Webhookdb::Fixtures::OrganizationErrorHandlers
+  extend Webhookdb::Fixtures
+
+  fixtured_class Webhookdb::Organization::ErrorHandler
+
+  base :organization_error_handler do
+    self.url ||= Faker::Internet.url
+  end
+
+  before_saving do |instance|
+    instance.organization ||= Webhookdb::Fixtures.organization.create
+    instance
+  end
+end

--- a/lib/webhookdb/jobs/organization_error_handler_dispatch.rb
+++ b/lib/webhookdb/jobs/organization_error_handler_dispatch.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "webhookdb/async/job"
+
+class Webhookdb::Jobs::OrganizationErrorHandlerDispatch
+  extend Webhookdb::Async::Job
+
+  sidekiq_options queue: "netout"
+
+  def perform(error_handler_id, payload)
+    eh = self.lookup_model(Webhookdb::Organization::ErrorHandler, error_handler_id)
+    self.set_job_tags(error_handler_id: eh.id, **eh.organization.log_tags)
+    begin
+      eh.dispatch(payload)
+      self.set_job_tags(result: "success")
+    rescue StandardError => e
+      # Don't bother logging these errors out
+      self.set_job_tags(result: "error")
+      self.logger.debug("organization_error_handler_post_error", error: e)
+      raise Amigo::Retry::OrDie.new(
+        Webhookdb::Organization::Alerting.error_handler_retries,
+        Webhookdb::Organization::Alerting.error_handler_retry_interval,
+      )
+    end
+  end
+end

--- a/lib/webhookdb/messages/error_generic_backfill.rb
+++ b/lib/webhookdb/messages/error_generic_backfill.rb
@@ -14,6 +14,8 @@ class Webhookdb::Messages::ErrorGenericBackfill < Webhookdb::Message::Template
     )
   end
 
+  attr_accessor :service_integration
+
   def initialize(service_integration, request_url:, request_method:, response_status:, response_body:)
     @service_integration = service_integration
     @request_url = request_url

--- a/lib/webhookdb/messages/error_icalendar_fetch.rb
+++ b/lib/webhookdb/messages/error_icalendar_fetch.rb
@@ -9,6 +9,8 @@ class Webhookdb::Messages::ErrorIcalendarFetch < Webhookdb::Message::Template
                     response_status: 403, request_url: "/foo", request_method: "GET", response_body: "hi",)
   end
 
+  attr_accessor :service_integration
+
   def initialize(service_integration, external_calendar_id, request_url:, request_method:, response_status:,
     response_body:)
     @service_integration = service_integration

--- a/lib/webhookdb/messages/error_signalwire_send_sms.rb
+++ b/lib/webhookdb/messages/error_signalwire_send_sms.rb
@@ -19,6 +19,8 @@ class Webhookdb::Messages::ErrorSignalwireSendSms < Webhookdb::Message::Template
     )
   end
 
+  attr_accessor :service_integration
+
   def initialize(service_integration, request_url:, request_method:, response_status:, response_body:)
     @service_integration = service_integration
     @request_url = request_url

--- a/lib/webhookdb/organization.rb
+++ b/lib/webhookdb/organization.rb
@@ -37,6 +37,7 @@ class Webhookdb::Organization < Webhookdb::Postgres::Model(:organizations)
               adder: ->(om) { om.update(organization_id: id, verified: false) },
               order: :id
   one_to_many :service_integrations, class: "Webhookdb::ServiceIntegration", order: :id
+  one_to_many :error_handlers, class: "Webhookdb::Organization::ErrorHandler", order: :id
   one_to_many :saved_queries, class: "Webhookdb::SavedQuery", order: :id
   one_to_many :saved_views, class: "Webhookdb::SavedView", order: :id
   one_to_many :webhook_subscriptions, class: "Webhookdb::WebhookSubscription", order: :id

--- a/lib/webhookdb/organization/error_handler.rb
+++ b/lib/webhookdb/organization/error_handler.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "premailer"
+
+class Webhookdb::Organization::ErrorHandler < Webhookdb::Postgres::Model(:organization_error_handlers)
+  include Webhookdb::Dbutil
+
+  plugin :timestamps
+
+  many_to_one :organization, class: "Webhookdb::Organization"
+  many_to_one :created_by, class: "Webhookdb::Customer"
+
+  # @param tmpl [Webhookdb::Message::Template]
+  def payload_for_template(tmpl)
+    params = {
+      error_type: tmpl.class.name.split("::").last.underscore,
+      details: tmpl.liquid_drops.to_h,
+      signature: tmpl.signature,
+      organization_key: self.organization.key,
+      service_integration_id: tmpl.service_integration.opaque_id,
+      service_integration_name: tmpl.service_integration.service_name,
+      service_integration_table: tmpl.service_integration.table_name,
+    }
+    recipient = Webhookdb::Message::Transport.for(:email).recipient(Webhookdb.support_email)
+    message = Webhookdb::Message.render(tmpl, :email, recipient)
+    message = message.to_s.strip
+    message = Premailer.new(
+      message,
+      with_html_string: true,
+      warn_level: Premailer::Warnings::SAFE,
+    )
+    message = message.to_plain_text
+    params[:message] = message
+    return params
+  end
+
+  def dispatch(payload)
+    if self.sentry?
+      self._handle_sentry(payload)
+      return
+    end
+
+    Webhookdb::Http.post(
+      self.url,
+      payload,
+      timeout: Webhookdb::Organization::Alerting.error_handler_timeout,
+      logger: self.logger,
+    )
+  end
+
+  def sentry?
+    u = URI(self.url)
+    return u.scheme == "sentry" || u.host&.end_with?("sentry.io")
+  end
+
+  MAX_SENTRY_TAG_CHARS = 200
+
+  # See https://develop.sentry.dev/sdk/data-model/envelopes/ for directly posting to Sentry.
+  # We do NOT want to use the SDK here, since we do not want to leak anything,
+  # and anyway, the runtime information is not important.
+  def _handle_sentry(payload)
+    payload = payload.deep_symbolize_keys
+    now = Time.now.utc
+    # We can assume the url is the Sentry DSN
+    u = URI(self.url)
+    key = u.user
+    project_id = u.path.delete("/")
+    # Give some valid value for this, though it's not accurate.
+    client = "sentry-ruby/5.22.1"
+    ts = now.to_i
+    # Auth headers are done by capturing an actual request. The docs aren't clear about their format.
+    # It's possible using the DSN auth would also work but let's use this.
+    headers = {
+      "Content-Type" => "application/x-sentry-envelope",
+      "X-Sentry-Auth" => "Sentry sentry_version=7, sentry_key=#{key}, sentry_client=#{client}, sentry_timestamp=#{ts}",
+    }
+    event_id = Uuidx.v4
+    # The first line will be used as the title.
+    message = "WebhookDB Error in #{payload.fetch(:service_integration_name)}\n\n#{payload.fetch(:message)}"
+    # Let the caller set the level through query params
+    level = URI.decode_www_form(u.query || "").to_h.fetch("level", "warning")
+
+    # Split structured data into 'extra' (cannot be searched on, just shows in the UI)
+    # and 'tags' (can be searched/faceted on, shows in the right bar).
+    ignore_tags = Webhookdb::Message::Template.new.liquid_drops.keys.to_set
+    tags, extra = payload.fetch(:details).partition do |k, v|
+      # Non-strings are always tags
+      next true unless v.is_a?(String)
+      # Never tag on basic stuff that doesn't change ever
+      next false if ignore_tags.include?(k)
+      # Unstructured strings may include spaces or braces, and are not tags
+      next false if v.include?(" ") || v.include?("{")
+      # If it's a small string, treat it as a tag.
+      v.size < MAX_SENTRY_TAG_CHARS
+    end
+
+    # Envelope structure is a multiline JSON file, I guess jsonl format
+    envelopes = [
+      {event_id:, sent_at: now.iso8601},
+      {type: "event", content_type: "application/json"},
+      {
+        event_id:,
+        timestamp: now.iso8601,
+        platform: "ruby",
+        level:,
+        transaction: payload.fetch(:service_integration_table),
+        release: "webhookdb@#{Webhookdb::RELEASE}",
+        environment: Webhookdb::RACK_ENV,
+        tags: tags.to_h,
+        extra: extra.to_h,
+        # We should use the same grouping for these messages as we would for emails
+        fingerprint: [payload.fetch(:signature)],
+        message: message,
+      },
+    ]
+    body = envelopes.map(&:to_json).join("\n")
+    store_url = URI(self.url)
+    store_url.scheme = "https" if store_url.scheme == "sentry"
+    store_url.user = nil
+    store_url.password = nil
+    store_url.path = "/api/#{project_id}/envelope/"
+    store_url.query = ""
+    Webhookdb::Http.post(
+      store_url.to_s,
+      body,
+      headers:,
+      timeout: Webhookdb::Organization::Alerting.error_handler_timeout,
+      logger: self.logger,
+    )
+  end
+
+  #
+  # :Sequel Hooks:
+  #
+
+  def before_create
+    self[:opaque_id] ||= Webhookdb::Id.new_opaque_id("oeh")
+  end
+end

--- a/lib/webhookdb/organization/error_handler.rb
+++ b/lib/webhookdb/organization/error_handler.rb
@@ -5,6 +5,8 @@ require "premailer"
 class Webhookdb::Organization::ErrorHandler < Webhookdb::Postgres::Model(:organization_error_handlers)
   include Webhookdb::Dbutil
 
+  DOCS_URL = "https://docs.webhookdb.com/docs/integrating/error-handlers.html"
+
   plugin :timestamps
 
   many_to_one :organization, class: "Webhookdb::Organization"

--- a/lib/webhookdb/postgres.rb
+++ b/lib/webhookdb/postgres.rb
@@ -59,6 +59,7 @@ module Webhookdb::Postgres
     "webhookdb/oauth/session",
     "webhookdb/organization",
     "webhookdb/organization/database_migration",
+    "webhookdb/organization/error_handler",
     "webhookdb/organization_membership",
     "webhookdb/role",
     "webhookdb/saved_query",

--- a/spec/webhookdb/api/error_handlers_spec.rb
+++ b/spec/webhookdb/api/error_handlers_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "webhookdb/api/error_handlers"
+
+RSpec.describe Webhookdb::API::ErrorHandlers, :db do
+  include Rack::Test::Methods
+
+  let(:app) { described_class.build_app }
+  let(:customer) { Webhookdb::Fixtures.customer.create }
+  let(:org) { Webhookdb::Fixtures.organization.with_admin(customer).create }
+
+  before(:each) do
+    login_as(customer)
+  end
+
+  describe "GET /v1/organizations/:key/error_handlers" do
+    it "returns a list of error handlers for the organization" do
+      eh = Webhookdb::Fixtures.organization_error_handler(organization: org).create
+      Webhookdb::Fixtures.organization_error_handler.create
+
+      get "/v1/organizations/#{org.key}/error_handlers"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.
+        that_includes(items: contain_exactly(include(id: eh.opaque_id)))
+    end
+
+    it "returns a message if organization has no error handlers" do
+      new_org = Webhookdb::Fixtures.organization.with_member(customer).create
+      get "/v1/organizations/#{new_org.key}/error_handlers"
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.
+        that_includes(message: include("have any error handlers"))
+    end
+  end
+
+  describe "POST /v1/organizations/:key/error_handlers/create" do
+    it "creates an error handler" do
+      post "/v1/organizations/#{org.key}/error_handlers/create", url: "https://foo.bar"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(url: "https://foo.bar")
+      expect(org.error_handlers).to contain_exactly(
+        have_attributes(created_by: customer, url: "https://foo.bar"),
+      )
+    end
+
+    it "fails if the URL is not valid (invalid url)" do
+      post "/v1/organizations/#{org.key}/error_handlers/create", url: ":123"
+
+      expect(last_response).to have_status(400)
+      expect(last_response).to have_json_body.that_includes(error: include(message: /URL is malformed/))
+    end
+
+    it "fails if the URL is not valid (invalid scheme)" do
+      post "/v1/organizations/#{org.key}/error_handlers/create", url: "ftp://foo.bar"
+
+      expect(last_response).to have_status(400)
+      expect(last_response).to have_json_body.that_includes(error: include(message: /URL is malformed/))
+    end
+
+    it "allows a sentry: protocol" do
+      post "/v1/organizations/#{org.key}/error_handlers/create", url: "sentry://foo.bar"
+
+      expect(last_response).to have_status(200)
+    end
+
+    it "errors if the customer is not an org admin" do
+      org.all_memberships.first.update(membership_role: Webhookdb::Role.non_admin_role)
+
+      post "/v1/organizations/#{org.key}/error_handlers/create", url: "https://foo.bar"
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(
+        error: include(message: "You must be an org admin to modify error handlers."),
+      )
+    end
+  end
+
+  describe "GET /v1/organizations/:key/error_handlers/:id" do
+    it "returns the error handler" do
+      eh = Webhookdb::Fixtures.organization_error_handler(organization: org).create
+
+      get "/v1/organizations/#{org.key}/error_handlers/#{eh.opaque_id}"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(url: eh.url, id: eh.opaque_id)
+    end
+
+    it "403s if the handler with the given opaque id does not exist" do
+      sq = Webhookdb::Fixtures.organization_error_handler.create
+
+      get "/v1/organizations/#{org.key}/error_handlers/#{sq.opaque_id}"
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(
+        error: include(message: include("There is no error handler with that")),
+      )
+    end
+  end
+
+  describe "POST /v1/organizations/:key/error_handlers/:id/delete" do
+    it "deletes the handler and returns correct response" do
+      eh = Webhookdb::Fixtures.organization_error_handler(organization: org).create
+
+      post "/v1/organizations/#{org.key}/error_handlers/#{eh.opaque_id}/delete"
+
+      expect(last_response).to have_status(200)
+      expect(last_response).to have_json_body.that_includes(
+        message: /You have successfully deleted the error handler /,
+      )
+      expect(eh).to be_destroyed
+    end
+
+    it "403s if request customer isn't an admin" do
+      org.all_memberships.first.update(membership_role: Webhookdb::Role.non_admin_role)
+      eh = Webhookdb::Fixtures.organization_error_handler(organization: org).create
+
+      post "/v1/organizations/#{org.key}/error_handlers/#{eh.opaque_id}/delete"
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(
+        error: include(message: "You must be an org admin to modify error handlers."),
+      )
+    end
+
+    it "403s if the handler does not belong to the org or does not exist" do
+      eh = Webhookdb::Fixtures.organization_error_handler.create
+
+      post "/v1/organizations/#{org.key}/error_handlers/#{eh.opaque_id}/delete"
+
+      expect(last_response).to have_status(403)
+      expect(last_response).to have_json_body.that_includes(
+        error: include(message: /There is no error handler with that id/),
+      )
+    end
+  end
+end

--- a/spec/webhookdb/api/system_spec.rb
+++ b/spec/webhookdb/api/system_spec.rb
@@ -38,4 +38,11 @@ RSpec.describe Webhookdb::API::System do
       expect(last_response).to have_status(200)
     end
   end
+
+  describe "POST /sink" do
+    it "204s" do
+      post "/sink"
+      expect(last_response).to have_status(204)
+    end
+  end
 end

--- a/spec/webhookdb/organization/error_handler_spec.rb
+++ b/spec/webhookdb/organization/error_handler_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "webhookdb/messages/specs"
+
+RSpec.describe Webhookdb::Organization::ErrorHandler, :db do
+  let(:org) { Webhookdb::Fixtures.organization.create }
+  let(:sint) { Webhookdb::Fixtures.service_integration.create(organization: org, table_name: "fake_v1_1452") }
+
+  let(:tmpl) do
+    tmpl = Webhookdb::Messages::Testers::Basic.new
+    tmpl.define_singleton_method(:signature) { "tester" }
+    si = sint
+    tmpl.define_singleton_method(:service_integration) { si }
+    tmpl
+  end
+
+  describe "payload_for_template" do
+    it "returns the expected payload" do
+      eh = Webhookdb::Fixtures.organization_error_handler(organization: org).create
+      p = eh.payload_for_template(tmpl)
+      expect(p).to eq(
+        {
+          details: {
+            api_url: "http://localhost:18001",
+            docs_url: "https://docs.webhookdb.com",
+            oss_repo: "https://github.com/webhookdb/webhookdb",
+            support_email: "hello@webhookdb.com",
+          },
+          error_type: "basic",
+          message: "email to hello@webhookdb.com",
+          organization_key: org.key,
+          service_integration_id: sint.opaque_id,
+          service_integration_name: sint.service_name,
+          service_integration_table: sint.table_name,
+          signature: "tester",
+        },
+      )
+    end
+  end
+
+  describe "dispatch" do
+    it "POSTS to the configured url with the payload" do
+      eh = Webhookdb::Fixtures.organization_error_handler.create(url: "https://fake.webhookdb.com/error")
+      req = stub_request(:post, "https://fake.webhookdb.com/error").
+        with(body: "{\"x\":1}").
+        to_return(status: 200, body: "", headers: {})
+      eh.dispatch({x: 1})
+      expect(req).to have_been_made
+    end
+
+    it "calls Sentry if the URL is a Sentry DSN" do
+      eh = Webhookdb::Fixtures.organization_error_handler.create(url: "https://public:private@abc.ingest.sentry.io/1")
+      payload = eh.payload_for_template(tmpl)
+      expect(Uuidx).to receive(:v4).and_return("a7eb3ee9-2ace-47cd-a18c-a33a3bc5e1b4")
+      # rubocop:disable Layout/LineLength
+      req = stub_request(:post, "https://abc.ingest.sentry.io/api/1/envelope/").
+        with(
+          body: '{"event_id":"a7eb3ee9-2ace-47cd-a18c-a33a3bc5e1b4","sent_at":"2025-01-07T20:30:15Z"}
+{"type":"event","content_type":"application/json"}
+{"event_id":"a7eb3ee9-2ace-47cd-a18c-a33a3bc5e1b4","timestamp":"2025-01-07T20:30:15Z","platform":"ruby","level":"warning","transaction":"fake_v1_1452","release":"webhookdb@unknown-release","environment":"test","tags":{},"extra":{"api_url":"http://localhost:18001","support_email":"hello@webhookdb.com","oss_repo":"https://github.com/webhookdb/webhookdb","docs_url":"https://docs.webhookdb.com"},"fingerprint":["tester"],"message":"WebhookDB Error in fake_v1\n\nemail to hello@webhookdb.com"}',
+          headers: {
+            "X-Sentry-Auth" => "Sentry sentry_version=7, sentry_key=public, sentry_client=sentry-ruby/5.22.1, sentry_timestamp=1736281815",
+          },
+        ).
+        to_return(status: 200, body: "", headers: {})
+      # rubocop:enable Layout/LineLength
+      Timecop.freeze(Time.at(1_736_281_815)) do
+        eh.dispatch(payload)
+      end
+      expect(req).to have_been_made
+    end
+
+    it "calls Sentry if the URL uses a 'sentry' protocol" do
+      eh = Webhookdb::Fixtures.organization_error_handler.create(url: "sentry://public@sentry.example.com/123")
+      payload = eh.payload_for_template(tmpl)
+      req = stub_request(:post, "https://sentry.example.com/api/123/envelope/").
+        to_return(status: 200, body: "", headers: {})
+      Timecop.freeze(Time.at(1_736_281_815)) do
+        eh.dispatch(payload)
+      end
+      expect(req).to have_been_made
+    end
+
+    it "adheres to the code explanation of how a Sentry payload is converted" do
+      eh = Webhookdb::Fixtures.organization_error_handler.create(url: "https://public@sentry.io/1?level=error")
+      tmpl.define_singleton_method(:liquid_drops) do
+        {
+          shortstr: "shortstring",
+          longstr: "x" * 201,
+          jsonstr: '{"x":1}',
+          spacestr: "space str",
+          num: 5,
+        }
+      end
+      payload = eh.payload_for_template(tmpl)
+      expect(Uuidx).to receive(:v4).and_return("a7eb3ee9-2ace-47cd-a18c-a33a3bc5e1b4")
+      # rubocop:disable Layout/LineLength
+      req = stub_request(:post, "https://sentry.io/api/1/envelope/").
+        with(
+          body: '{"event_id":"a7eb3ee9-2ace-47cd-a18c-a33a3bc5e1b4","sent_at":"2025-01-07T20:30:15Z"}
+{"type":"event","content_type":"application/json"}
+{"event_id":"a7eb3ee9-2ace-47cd-a18c-a33a3bc5e1b4","timestamp":"2025-01-07T20:30:15Z","platform":"ruby","level":"error","transaction":"fake_v1_1452","release":"webhookdb@unknown-release","environment":"test","tags":{"shortstr":"shortstring","num":5},"extra":{"longstr":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","jsonstr":"{\"x\":1}","spacestr":"space str"},"fingerprint":["tester"],"message":"WebhookDB Error in fake_v1\n\nemail to hello@webhookdb.com"}',
+        ).
+        to_return(status: 200, body: "", headers: {})
+      # rubocop:enable Layout/LineLength
+      Timecop.freeze(Time.at(1_736_281_815)) do
+        eh.dispatch(payload)
+      end
+      expect(req).to have_been_made
+    end
+  end
+end


### PR DESCRIPTION
Adds error handling system into `Organization::Alerting`. Allows customers to register centralized error handling, such as an arbitrary endpoint, or Sentry, to receive alerts about failed replicators.