### PR TITLE
Update Front convos when a signalwire message fails to send

### DIFF
--- a/lib/webhookdb/jobs/front_signalwire_message_channel_sync_inbound.rb
+++ b/lib/webhookdb/jobs/front_signalwire_message_channel_sync_inbound.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "webhookdb/async/job"
+require "webhookdb/jobs"
+
+# See +Webhookdb::Replicator::FrontSignalwireMessageChannelAppV1#alert_async_failed_signalwire_send+
+# for why we need to pull this into an async job.
+class Webhookdb::Jobs::FrontSignalwireMessageChannelSyncInbound
+  extend Webhookdb::Async::Job
+
+  def perform(service_integration_id, kwargs)
+    sint = self.lookup_model(Webhookdb::ServiceIntegration, service_integration_id)
+    sint.replicator.sync_front_inbound_message(**kwargs.symbolize_keys)
+  end
+end


### PR DESCRIPTION
When Signalwire fails to send a message (but still creates the record), update the conversation in Front with an indication that the message failed to send through signalwire.

This prevents situations where messages are sent by Front agents but cannot be received, and the agent doesn't know about it.

Fixes https://github.com/webhookdb/webhookdb/issues/904