### PR TITLE
Ignore LAST-MODIFIED when checking for changes

### DIFF
--- a/lib/webhookdb/replicator/icalendar_event_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_event_v1.rb
@@ -220,12 +220,12 @@ class Webhookdb::Replicator::IcalendarEventV1 < Webhookdb::Replicator::Base
   end
 
   def _update_where_expr
-    # last_modified_at is set to either the LAST-MODIFIED value, OR the row_updated_at timestamp.
-    # Many feeds do not have LAST-MODIFIED, so all rows get updated.
     # Compare against data to avoid the constant writes. JSONB != operations are very fast,
     # so this should not be any real performance issue.
-    return (self.qualified_table_sequel_identifier[:data] !~ Sequel[:excluded][:data]) &
-        (self.qualified_table_sequel_identifier[:last_modified_at] < Sequel[:excluded][:last_modified_at])
+    # last_modified_at is unreliable because LAST-MODIFIED is unreliable,
+    # even in feeds it is set. There are cases, such as adding an EXDATE to an RRULE,
+    # that do not trigger LAST-MODIFIED changes.
+    return self.qualified_table_sequel_identifier[:data] !~ Sequel[:excluded][:data]
   end
 
   # @param [Array<String>] lines

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -362,51 +362,6 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
         UID:c7614cff-3549-4a00-9152-d25cc1fe077d
         DTSTART:20080212
         DTEND:20080213
-        LAST-MODIFIED:20150421T141403Z
-        END:VEVENT
-        END:VCALENDAR
-      ICAL
-      updated1 = v1.gsub("Version1", "Version2")
-      updated2 = v1.gsub("Version1", "Version3").gsub("20150421T141403Z", "20160421T141403Z")
-      updated3 = v1.gsub("Version1", "Version4").gsub("\nLAST-MODIFIED:20150421T141403Z", "")
-      req = stub_request(:get, "https://feed.me").
-        and_return(
-          {status: 200, headers: {"Content-Type" => "text/calendar"}, body: v1},
-          {status: 200, headers: {"Content-Type" => "text/calendar"}, body: updated1},
-          {status: 200, headers: {"Content-Type" => "text/calendar"}, body: updated2},
-          {status: 200, headers: {"Content-Type" => "text/calendar"}, body: updated3},
-        )
-      row = insert_calendar_row(ics_url: "https://feed.me", external_id: "abc")
-      svc.sync_row(row)
-      expect(event_svc.admin_dataset(&:all)).to contain_exactly(
-        include(data: hash_including("SUMMARY" => {"v" => "Version1"})),
-      )
-      svc.sync_row(row)
-      expect(event_svc.admin_dataset(&:all)).to contain_exactly(
-        include(data: hash_including("SUMMARY" => {"v" => "Version1"})),
-      )
-      svc.sync_row(row)
-      expect(event_svc.admin_dataset(&:all)).to contain_exactly(
-        include(data: hash_including("SUMMARY" => {"v" => "Version3"})),
-      )
-      svc.sync_row(row)
-      expect(event_svc.admin_dataset(&:all)).to contain_exactly(
-        include(data: hash_including("SUMMARY" => {"v" => "Version4"})),
-      )
-      expect(req).to have_been_made.times(4)
-    end
-
-    it "skips rows that have not been modified, which do not have a LAST-MODIFIED timestamp" do
-      v1 = <<~ICAL
-        BEGIN:VCALENDAR
-        VERSION:2.0
-        PRODID:-//ZContent.net//Zap Calendar 1.0//EN
-        CALSCALE:GREGORIAN
-        BEGIN:VEVENT
-        SUMMARY:Version1
-        UID:c7614cff-3549-4a00-9152-d25cc1fe077d
-        DTSTART:20080212
-        DTEND:20080213
         END:VEVENT
         END:VCALENDAR
       ICAL
@@ -429,7 +384,7 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
       expect(req).to have_been_made.times(3)
     end
 
-    it "uses UTC for unregonized timezones" do
+    it "uses UTC for unrecognized timezones" do
       body = <<~ICAL
         BEGIN:VCALENDAR
         BEGIN:VEVENT


### PR DESCRIPTION
LAST-MODIFIED is unreliable.
We found cases where icloud does not modify LAST-MODIFIED even when exclusions (EXDATE) are added for recurring events. So, for example, if an EXDATE is added over the 12th event in a recurring series, new data
(for what was the 13th event in the series)
does not overwrite the 12th event,
because LAST-MODIFIED has not changed.

It would be possible to solve this problem *only* for recurring events, but I'm not sure that `data != data` has much different performance than `last_modified_at < last_modified_at`,
especially since we check `data` for rows where the feed doesn't have a `LAST-MODIFIED` anyway.

Feeds should be reprocessed after deploying this change, to make sure any incorrect feeds have their events replaced. You can run the following code from a console,
which will ensure feeds will not noop even if the
feed has not changed:

```ruby
Webhookdb::ServiceIntegration.where(service_name: 'icalendar_calendar_v1').each { |sint| sint.replicator.admin_dataset { |ds| ds.update(last_fetch_context: nil) } }
```
