### PR TITLE
Fixes: Icalendar, threadpool, logging, Github alerts, alert encoding, deprecations

### DIFF
--- a/lib/webhookdb.rb
+++ b/lib/webhookdb.rb
@@ -19,6 +19,8 @@ Money.locale_backend = :i18n
 Money.default_currency = "USD"
 Money.rounding_mode = BigDecimal::ROUND_HALF_UP
 
+ActiveSupport.to_time_preserves_timezone = true
+
 module Appydays::Configurable
   def self.fetch_env(keys, default=:__keyerror, env: ENV)
     keys = [keys] unless keys.respond_to?(:to_ary)

--- a/lib/webhookdb/icalendar.rb
+++ b/lib/webhookdb/icalendar.rb
@@ -27,7 +27,7 @@ module Webhookdb::Icalendar
     # Number of threads for the 'precheck' threadpool, used when enqueing icalendar sync jobs.
     # Since the precheck process uses many threads, but each check is resource-light and not latency-sensitive,
     # we use a shared threadpool for it.
-    setting :precheck_feed_change_pool_size, 100
+    setting :precheck_feed_change_pool_size, 12
 
     # Cancelled events that were last updated this long ago are deleted from the database.
     setting :stale_cancelled_event_threshold_days, 20

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
@@ -55,7 +55,7 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
             rows_needing_sync(ds).
             order(:pk).
             select(:external_id, :ics_url, :last_fetch_context)
-          row_ds.each do |row|
+          row_ds.paged_each(rows_per_fetch: 500, cursor_name: "ical_enqueue_#{sint.id}_cursor") do |row|
             threadpool.post do
               break unless repl.feed_changed?(row)
               calendar_external_id = row.fetch(:external_id)

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
@@ -41,10 +41,14 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
   def _perform
     max_projected_out_seconds = Webhookdb::Icalendar.sync_period_splay_hours.hours.to_i
     total_count = 0
-    threadpool = Concurrent::CachedThreadPool.new(
+    threadpool = Concurrent::ThreadPoolExecutor.new(
       name: "ical-precheck",
-      max_queue: Webhookdb::Icalendar.precheck_feed_change_pool_size,
+      max_threads: Webhookdb::Icalendar.precheck_feed_change_pool_size,
+      min_threads: 1,
+      idletime: 40,
+      max_queue: 0,
       fallback_policy: :caller_runs,
+      synchronous: false,
     )
     Webhookdb::ServiceIntegration.dataset.where_each(service_name: "icalendar_calendar_v1") do |sint|
       sint_count = 0

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -291,6 +291,7 @@ The secret to use for signing is:
           self._handle_retryable_down_error!(e, request_url:, calendar_external_id:)
         end
       when Down::TimeoutError, Down::ConnectionError, Down::InvalidUrl,
+        Errno::ECONNRESET,
         URI::InvalidURIError,
         HTTPX::NativeResolveError, HTTPX::InsecureRedirectError,
         HTTPX::Connection::HTTP2::Error,

--- a/lib/webhookdb/replicator/signalwire_message_v1.rb
+++ b/lib/webhookdb/replicator/signalwire_message_v1.rb
@@ -200,7 +200,6 @@ Press 'Show' next to the newly-created API token, and copy it.)
       request_url = e.uri.to_s
       request_method = e.http_method
     end
-    self.logger.warn("signalwire_backfill_error", response_body:, response_status:, request_url:)
     message = Webhookdb::Messages::ErrorGenericBackfill.new(
       self.service_integration,
       response_status:,

--- a/lib/webhookdb/sync_target.rb
+++ b/lib/webhookdb/sync_target.rb
@@ -487,7 +487,7 @@ class Webhookdb::SyncTarget < Webhookdb::Postgres::Model(:sync_targets)
       self.perform_db_op do
         self.sync_target.save_changes
       end
-      self.sync_target.logger.error("sync_target_pool_timeout_error", e, self.sync_target.log_tags)
+      self.sync_target.logger.error("sync_target_pool_timeout_error", self.sync_target.log_tags, e)
     rescue Webhookdb::Http::Error, Errno::ECONNRESET, Net::ReadTimeout, Net::OpenTimeout, OpenSSL::SSL::SSLError => e
       # This is handled well so no need to re-raise.
       # We already committed the last page that was successful,
@@ -499,7 +499,7 @@ class Webhookdb::SyncTarget < Webhookdb::Postgres::Model(:sync_targets)
       # Don't spam our logs with downstream errors
       idem_key = "sync_target_http_error-#{self.sync_target.id}-#{e.class.name}"
       Webhookdb::Idempotency.every(1.hour).in_memory.under_key(idem_key) do
-        self.sync_target.logger.warn("sync_target_http_error", e, self.sync_target.log_tags)
+        self.sync_target.logger.warn("sync_target_http_error", self.sync_target.log_tags, e)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,8 +54,6 @@ RSpec.configure do |config|
   config.disable_monkey_patching!
   config.default_formatter = "doc" if config.files_to_run.one?
 
-  # Used in match_time matcher
-  ActiveSupport.to_time_preserves_timezone = true
   config.include(Appydays::SpecHelpers)
   config.include(Appydays::Configurable::SpecHelpers)
   config.include(Appydays::Loggable::SpecHelpers)

--- a/spec/webhookdb/organization/alerting_spec.rb
+++ b/spec/webhookdb/organization/alerting_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe Webhookdb::Organization::Alerting, :db do
           ),
         )
       end
+
+      it "serializes job args without bothering sidekiq" do
+        eh1 = Webhookdb::Fixtures.organization_error_handler(organization: org).create
+        req = stub_request(:post, eh1.url).and_return(status: 200)
+        tmpl.define_singleton_method(:liquid_drops) do
+          {msg: (+"not encoded \xC2\xA9 copyright").force_encoding("ASCII-8BIT")}
+        end
+        alerting.dispatch_alert(tmpl)
+        expect(req).to have_been_made
+      end
     end
   end
 

--- a/spec/webhookdb/replicator/github_repository_event_v1_spec.rb
+++ b/spec/webhookdb/replicator/github_repository_event_v1_spec.rb
@@ -314,6 +314,25 @@ RSpec.describe Webhookdb::Replicator::GithubRepositoryEventV1, :db do
     end
   end
 
+  it_behaves_like "a replicator that alerts on backfill auth errors" do
+    let(:sint_params) { {api_url: "my/code"} }
+    let(:template_name) { "errors/generic_backfill" }
+
+    def stub_service_request
+      return stub_request(:get, "https://api.github.com/repos/my/code/events?per_page=100")
+    end
+
+    def handled_responses
+      return [
+        [:and_return, {status: 401, body: "Unauthorized"}],
+      ]
+    end
+
+    def unhandled_response
+      return [:and_return, {status: 500, body: "Error"}]
+    end
+  end
+
   # Tested through github_issue
   # describe "webhook validation"
   # describe "state machine calculation"


### PR DESCRIPTION
Ical: Use different threadpool

CachedThreadpool was creating a ton of threads,
I am not sure of the point of it.
Instead, use the right threadpool, which will limit itself
to creating 12 threads.

---

Move ActiveSupport timezone deprecation fix to main file

---

Ical: Ignore econnresets

They are normal types of errors (403, etc).

---

Fix org alerting error with invalid encoding

Sending an org alert can fail because the response body
rendered into the message is the wrong encoding.
So when we serialize to JSON for Sidekiq,
we get a different string than the input
(think about how UTF-32 and UTF-8 would render
a high-value character differently).

Some icalendars get HTML error pages including invalid encoding.

Instead, dump and re-parse to work around this particular issue
with strict Sidekiq args; it wasn't feasible to force-encode
since this problem can come from any part of the system,
not just icalendar.

See spec for more information.

---

Github repo: 401s during backfill should alert

Do not raise sentry errors, report it.

---

Icalendar: Use server cursor for enqueing

Paginate the each fetches.
We don't want too many calendar rows into Ruby memory.

---

Fix sync target error log messages

Was out of order and leading to bad data in logs.