### PR TITLE
Add icalproxy support

### DIFF
--- a/lib/webhookdb/api/icalproxy.rb
+++ b/lib/webhookdb/api/icalproxy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "webhookdb/api"
+require "webhookdb/jobs/icalendar_enqueue_syncs_for_urls"
+
+class Webhookdb::API::Icalproxy < Webhookdb::API::V1
+  resource :icalproxy do
+    resource :webhook do
+      post do
+        merror!(402, "Api key not configured") unless Webhookdb::Icalendar.proxy_api_key.present?
+        request_key = request.env["HTTP_AUTHORIZATION"] || ""
+        configured_key = "Apikey #{Webhookdb::Icalendar.proxy_api_key}"
+        verified = request_key && ActiveSupport::SecurityUtils.secure_compare(request_key, configured_key)
+        merror!(401, "Invalid api key") unless verified
+        urls = params.fetch(:urls)
+        Webhookdb::Jobs::IcalendarEnqueueSyncsForUrls.perform_async(urls)
+        status 202
+        present({o: "k"})
+      end
+    end
+  end
+end

--- a/lib/webhookdb/apps.rb
+++ b/lib/webhookdb/apps.rb
@@ -16,6 +16,7 @@ require "webhookdb/api/auth"
 require "webhookdb/api/db"
 require "webhookdb/api/demo"
 require "webhookdb/api/error_handlers"
+require "webhookdb/api/icalproxy"
 require "webhookdb/api/install"
 require "webhookdb/api/me"
 require "webhookdb/api/organizations"
@@ -79,6 +80,7 @@ module Webhookdb::Apps
     mount Webhookdb::API::Db
     mount Webhookdb::API::Demo
     mount Webhookdb::API::ErrorHandlers
+    mount Webhookdb::API::Icalproxy
     mount Webhookdb::API::Install
     mount Webhookdb::API::Me
     mount Webhookdb::API::Organizations

--- a/lib/webhookdb/http.rb
+++ b/lib/webhookdb/http.rb
@@ -129,3 +129,6 @@ class HTTPX::Response::Body
     @encoding = "#{md[1]}-#{md[2]}"
   end
 end
+
+# Not sure why, but Down uses this, loads the plugin, but the constant isn't defined.
+require "httpx/plugins/follow_redirects"

--- a/lib/webhookdb/icalendar.rb
+++ b/lib/webhookdb/icalendar.rb
@@ -10,7 +10,7 @@ module Webhookdb::Icalendar
   include Appydays::Configurable
 
   configurable(:icalendar) do
-    # Do not store events older then this when syncing recurring events.
+    # Do not store events older than this when syncing recurring events.
     # Many icalendar feeds are misconfigured and this prevents enumerating 2000+ years of recurrence.
     setting :oldest_recurring_event, "2000-01-01", convert: ->(s) { Date.parse(s) }
     # Calendars feeds are considered 'fresh' if they have been synced this long ago or less.
@@ -33,5 +33,13 @@ module Webhookdb::Icalendar
     setting :stale_cancelled_event_threshold_days, 20
     # The stale row deleter job will look for rows this far before the threshold.
     setting :stale_cancelled_event_lookback_days, 3
+
+    # The URL of the icalproxy server, if using one.
+    # See https://github.com/webhookdb/icalproxy for more info.
+    # Used to get property HTTP semantics for any icalendar feed, like Etag and HEAD requests.
+    setting :proxy_url, ""
+    # Api key of the icalproxy server, if using one.
+    # See https://github.com/webhookdb/icalproxy
+    setting :proxy_api_key, ""
   end
 end

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs_for_urls.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs_for_urls.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "webhookdb/async/job"
+
+class Webhookdb::Jobs::IcalendarEnqueueSyncsForUrls
+  extend Webhookdb::Async::Job
+
+  def perform(urls)
+    self.set_job_tags(url_count: urls.length)
+    row_count = 0
+    Webhookdb::ServiceIntegration.where(service_name: "icalendar_calendar_v1").each do |sint|
+      sint.replicator.admin_dataset do |ds|
+        affected_row_ext_ids = ds.where(ics_url: urls).select_map(:external_id)
+        affected_row_ext_ids.each do |ext_id|
+          Webhookdb::Jobs::IcalendarSync.perform_async(sint.id, ext_id)
+        end
+        row_count += affected_row_ext_ids.length
+      end
+    end
+    self.set_job_tags(result: "icalendar_enqueued_syncs", row_count:)
+  end
+end

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -256,6 +256,11 @@ The secret to use for signing is:
       "Accept" => "text/calendar,*/*",
     }
     headers["If-None-Match"] = last_fetch_context["etag"] if last_fetch_context & ["etag"]
+    if (proxy_url = Webhookdb::Icalendar.proxy_url).present?
+      request_url = "#{proxy_url.delete_suffix('/')}/?url=#{URI.encode_www_form_component(request_url)}"
+      headers["Authorization"] = "Apikey #{Webhookdb::Icalendar.proxy_api_key}" if
+        Webhookdb::Icalendar.proxy_api_key.present?
+    end
     resp = Webhookdb::Http.chunked_download(request_url, rewindable: false, headers:)
     return resp
   end

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -326,12 +326,17 @@ The secret to use for signing is:
           417, # If someone uses an Outlook HTML calendar, fetch gives us a 417
           422, # Sometimes used instead of 404
           429, # Usually 429s are retried (as above), but in some cases they're not.
+          500, 503, 504, # Intermittent server issues, usually
+          599, # Represents a timeout in icalproxy
         ]
         # For most client errors, we can't do anything about it. For example,
         # and 'unshared' URL could result in a 401, 403, 404, or even a 405.
         # For now, other client errors, we can raise on,
         # in case it's something we can fix/work around.
         # For example, it's possible something like a 415 is a WebhookDB issue.
+        if response_status == 421 && (origin_err = e.response.headers["Ical-Proxy-Origin-Error"])
+          response_status = origin_err.to_i
+        end
         raise e unless expected_errors.include?(response_status)
         response_body = self._safe_read_body(e)
       when Down::ServerError

--- a/spec/webhookdb/api/icalproxy_spec.rb
+++ b/spec/webhookdb/api/icalproxy_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "webhookdb/api/icalproxy"
+
+RSpec.describe Webhookdb::API::Icalproxy, :async, :db do
+  include Rack::Test::Methods
+
+  let(:app) { described_class.build_app }
+
+  describe "POST /v1/stripe/icalproxy", reset_configuration: Webhookdb::Icalendar do
+    before(:each) do
+      Webhookdb::Icalendar.proxy_api_key = "mykey"
+    end
+
+    it "errors if no api key is configured" do
+      Webhookdb::Icalendar.proxy_api_key = ""
+      header "Authorization", "Apikey mykey"
+
+      post "/v1/icalproxy/webhook", {urls: ["abc"]}
+      expect(last_response).to have_status(402)
+    end
+
+    it "errors for a missing auth header" do
+      post "/v1/icalproxy/webhook", {urls: ["abc"]}
+      expect(last_response).to have_status(401)
+    end
+
+    it "errors for a bad auth header" do
+      header "Authorization", "Apikey nope"
+      post "/v1/icalproxy/webhook", {urls: ["abc"]}
+      expect(last_response).to have_status(401)
+    end
+
+    it "enqueues an async job with the given urls", sidekiq: :fake do
+      header "Authorization", "Apikey mykey"
+
+      post "/v1/icalproxy/webhook", {urls: ["abc", "xyz"]}
+      expect(last_response).to have_status(202)
+
+      expect(Sidekiq).to have_queue("default").consisting_of(
+        job_hash(
+          Webhookdb::Jobs::IcalendarEnqueueSyncsForUrls,
+          args: [["abc", "xyz"]],
+        ),
+      )
+    end
+  end
+end


### PR DESCRIPTION
See https://github.com/webhookdb/icalproxy for the proxy server.

---

Add proxy webhook support

Calls can come into /v1/icalproxy/webhook
and will trigger an immediate sync.

---

Add proxy fetching support

---

Store and use etag when fetching feed
