### PR TITLE
Optimize logged webhook trimming

### DIFF
--- a/db/migrations/050_logged_webhook_indices.rb
+++ b/db/migrations/050_logged_webhook_indices.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  no_transaction
+  up do
+    # These are optimized for Webhookdb::LoggedWebhook.trim. See code for details/coupling.
+    run "CREATE INDEX CONCURRENTLY logged_webhooks_trim_unowned_idx ON logged_webhooks(inserted_at) " \
+        "WHERE organization_id IS NULL"
+    run "CREATE INDEX CONCURRENTLY logged_webhooks_trim_success_idx ON logged_webhooks(inserted_at) " \
+        "WHERE organization_id IS NOT NULL AND response_status < 400 AND truncated_at IS NULL"
+    run "CREATE INDEX CONCURRENTLY logged_webhooks_delete_success_idx ON logged_webhooks(inserted_at) " \
+        "WHERE organization_id IS NOT NULL AND response_status < 400 AND truncated_at IS NOT NULL"
+    run "CREATE INDEX CONCURRENTLY logged_webhooks_trim_failures_idx ON logged_webhooks(inserted_at) " \
+        "WHERE organization_id IS NOT NULL AND response_status >= 400 AND truncated_at IS NULL"
+    run "CREATE INDEX CONCURRENTLY logged_webhooks_delete_failures_idx ON logged_webhooks(inserted_at) " \
+        "WHERE organization_id IS NOT NULL AND response_status >= 400 AND truncated_at IS NOT NULL"
+  end
+  down do
+    run "DROP INDEX logged_webhooks_trim_unowned_idx"
+    run "DROP INDEX logged_webhooks_trim_success_idx"
+    run "DROP INDEX logged_webhooks_delete_success_idx"
+    run "DROP INDEX logged_webhooks_trim_failures_idx"
+    run "DROP INDEX logged_webhooks_delete_failures_idx"
+  end
+end

--- a/lib/webhookdb/fixtures/logged_webhooks.rb
+++ b/lib/webhookdb/fixtures/logged_webhooks.rb
@@ -35,6 +35,10 @@ module Webhookdb::Fixtures::LoggedWebhooks
     self.response_status = rand(400..599)
   end
 
+  decorator :truncated do |t=Time.now|
+    self.truncated_at = t
+  end
+
   decorator :with_organization do |org={}|
     org = Webhookdb::Fixtures.organization.create(org) unless org.is_a?(Webhookdb::Organization)
     self.organization = org


### PR DESCRIPTION
We were setting truncated_at whenever we trimmed,
rather than only setting it on untruncated webhooks.

During the course of this fix it was also clear we weren't using indices effectively when trimming. We had one index on inserted_at, but this table can be very very large, so it led to many long index scans that needed to eliminate rows with a filter.

This creates separate partial indices for each query (which together cover the table space), ensuring minimal scans.

Tested with production to make sure the indices are used.
