### PR TITLE
Support partitioned replicators

### DIFF
--- a/db/migrations/051_partitioning.rb
+++ b/db/migrations/051_partitioning.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:service_integrations) do
+      add_column :partition_value, :int, default: 0, null: false
+    end
+  end
+end

--- a/lib/webhookdb/backfiller.rb
+++ b/lib/webhookdb/backfiller.rb
@@ -108,7 +108,7 @@ class Webhookdb::Backfiller
       update_expr = self.upserting_replicator._upsert_update_expr(rows_to_insert.first)
       self.upserting_replicator.admin_dataset(timeout: :fast) do |ds|
         insert_ds = ds.insert_conflict(
-          target: self.upserting_replicator._remote_key_column.name,
+          target: self.upserting_replicator._upsert_conflict_target,
           update: update_expr,
           update_where: update_where_expr,
         )

--- a/lib/webhookdb/db_adapter.rb
+++ b/lib/webhookdb/db_adapter.rb
@@ -2,6 +2,7 @@
 
 class Webhookdb::DBAdapter
   require "webhookdb/db_adapter/column_types"
+  require "webhookdb/db_adapter/partitioning"
 
   class UnsupportedAdapter < Webhookdb::ProgrammingError; end
 
@@ -149,20 +150,30 @@ class Webhookdb::DBAdapter
     raise NotImplementedError
   end
 
+  # Return the CREATE TABLE sql to create table with columns.
   # @param [Table] table
   # @param [Array<Column>] columns
   # @param [Schema] schema
-  # @param [Boolean] if_not_exists
+  # @param [TrueClass,FalseClass] if_not_exists If true, use CREATE TABLE IF NOT EXISTS.
+  # @param partition [Webhookdb::DBAdapter::Partitioning,nil] If provided,
+  #   adds a "PARTITION BY HASH (partition_column_name)" to the returned SQL.
   # @return [String]
-  def create_table_sql(table, columns, schema: nil, if_not_exists: false)
+  def create_table_sql(table, columns, schema: nil, if_not_exists: false, partition: nil)
     raise NotImplementedError
   end
+
+  # We write our own escaper because we want to only escape what's needed;
+  # otherwise we want to avoid quoting identifiers.
+  def escape_identifier(s) = raise NotImplementedError
 
   # @param [Index] index
   # @return [String]
   def create_index_sql(index, concurrently:)
     raise NotImplementedError
   end
+
+  # @param column [Column] The column to create SQL for.
+  def create_column_sql(column) = raise NotImplementedError
 
   # @param [Table] table
   # @param [Column] column

--- a/lib/webhookdb/db_adapter/default_sql.rb
+++ b/lib/webhookdb/db_adapter/default_sql.rb
@@ -8,17 +8,6 @@ module Webhookdb::DBAdapter::DefaultSql
     return s
   end
 
-  def create_table_sql(table, columns, if_not_exists: false)
-    createtable = +"CREATE TABLE "
-    createtable << "IF NOT EXISTS " if if_not_exists
-    createtable << self.qualify_table(table)
-    lines = ["#{createtable} ("]
-    columns[0...-1]&.each { |c| lines << "  #{self.column_create_sql(c)}," }
-    lines << "  #{self.column_create_sql(columns.last)}"
-    lines << ")"
-    return lines.join("\n")
-  end
-
   def identifier_quote_char
     raise NotImplementedError
   end

--- a/lib/webhookdb/db_adapter/default_sql.rb
+++ b/lib/webhookdb/db_adapter/default_sql.rb
@@ -8,9 +8,7 @@ module Webhookdb::DBAdapter::DefaultSql
     return s
   end
 
-  def identifier_quote_char
-    raise NotImplementedError
-  end
+  def identifier_quote_char = raise NotImplementedError
 
   # We write our own escaper because we want to only escape what's needed;
   # otherwise we want to avoid quoting identifiers.

--- a/lib/webhookdb/db_adapter/partitioning.rb
+++ b/lib/webhookdb/db_adapter/partitioning.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Webhookdb::DBAdapter::Partitioning < Webhookdb::TypedStruct
+  HASH = :hash
+  RANGE = :range
+
+  attr_reader :by, :column
+end

--- a/lib/webhookdb/db_adapter/pg.rb
+++ b/lib/webhookdb/db_adapter/pg.rb
@@ -11,9 +11,7 @@ class Webhookdb::DBAdapter::PG < Webhookdb::DBAdapter
   VERIFY_TIMEOUT = 2
   VERIFY_STATEMENT = "SELECT 1"
 
-  def identifier_quote_char
-    return '"'
-  end
+  def identifier_quote_char = '"'
 
   def create_index_sql(index, concurrently:)
     tgts = index.targets.map { |c| self.escape_identifier(c.name) }.join(", ")
@@ -57,7 +55,10 @@ class Webhookdb::DBAdapter::PG < Webhookdb::DBAdapter
       end
     end
     tbl_lines = columns.map { |c| self.create_column_sql(c) }
-    tbl_lines.concat(partitioned_pks.map { |c| "PRIMARY KEY (#{partition.column}, #{c.name})" })
+    tbl_lines.concat(partitioned_pks.map do |c|
+      pkcols = [partition.column, c.name].uniq.join(", ")
+      "PRIMARY KEY (#{pkcols})"
+    end)
     tbl_lines.concat(partitioned_uniques.map { |c| "UNIQUE (#{partition.column}, #{c.name})" })
     lines = ["#{createtable} ("]
     lines << ("  " + tbl_lines.join(",\n  "))

--- a/lib/webhookdb/db_adapter/pg.rb
+++ b/lib/webhookdb/db_adapter/pg.rb
@@ -26,7 +26,57 @@ class Webhookdb::DBAdapter::PG < Webhookdb::DBAdapter
     return "CREATE#{uniq} INDEX#{concurrent} IF NOT EXISTS #{idxname} ON #{tblname} (#{tgts})#{where}"
   end
 
-  def column_create_sql(column)
+  def create_table_sql(table, columns, if_not_exists: false, partition: nil)
+    columns = columns.to_a
+    createtable = +"CREATE TABLE "
+    createtable << "IF NOT EXISTS " if if_not_exists
+    createtable << self.qualify_table(table)
+
+    partitioned_pks = []
+    partitioned_uniques = []
+    if partition
+      # We cannot use PRIMARY KEY or UNIQUE when partitioning,
+      # so set those columns as if they're not
+      columns.each_with_index do |c, i|
+        if c.pk?
+          # Set the type to the serial type as if it's a normal PK
+          type = case c.type
+            when BIGINT
+              :bigserial
+            when INTEGER
+              :serial
+            else
+              c.type
+          end
+          columns[i] = c.change(pk: false, type:)
+          partitioned_pks << c
+        elsif c.unique?
+          columns[i] = c.change(unique: false)
+          partitioned_uniques << c
+        end
+      end
+    end
+    tbl_lines = columns.map { |c| self.create_column_sql(c) }
+    tbl_lines.concat(partitioned_pks.map { |c| "PRIMARY KEY (#{partition.column}, #{c.name})" })
+    tbl_lines.concat(partitioned_uniques.map { |c| "UNIQUE (#{partition.column}, #{c.name})" })
+    lines = ["#{createtable} ("]
+    lines << ("  " + tbl_lines.join(",\n  "))
+    lines << ")"
+    if partition
+      m = case partition.by
+        when Webhookdb::DBAdapter::Partitioning::HASH
+          "HASH"
+        when Webhookdb::DBAdapter::Partitioning::RANGE
+          "RANGE"
+        else
+          raise ArgumentError, "unknown partition method: #{partition.by}"
+      end
+      lines << "PARTITION BY #{m} (#{partition.column})"
+    end
+    return lines.join("\n")
+  end
+
+  def create_column_sql(column)
     modifiers = +""
     coltype = COLTYPE_MAP.fetch(column.type)
     if column.pk?
@@ -42,8 +92,15 @@ class Webhookdb::DBAdapter::PG < Webhookdb::DBAdapter
     return "#{colname} #{coltype}#{modifiers}"
   end
 
+  def create_hash_partition_sql(table, partition_count, remainder)
+    tbl = self.qualify_table(table)
+    s = "CREATE TABLE #{tbl}_#{remainder} PARTITION OF #{tbl} " \
+        "FOR VALUES WITH (MODULUS #{partition_count}, REMAINDER #{remainder})"
+    return s
+  end
+
   def add_column_sql(table, column, if_not_exists: false)
-    c = self.column_create_sql(column)
+    c = self.create_column_sql(column)
     ifne = if_not_exists ? " IF NOT EXISTS" : ""
     return "ALTER TABLE #{self.qualify_table(table)} ADD COLUMN#{ifne} #{c}"
   end
@@ -92,5 +149,7 @@ class Webhookdb::DBAdapter::PG < Webhookdb::DBAdapter
     TEXT_ARRAY => "text[]",
     TIMESTAMP => "timestamptz",
     UUID => "uuid",
+    :serial => "serial",
+    :bigserial => "bigserial",
   }.freeze
 end

--- a/lib/webhookdb/db_adapter/snowflake.rb
+++ b/lib/webhookdb/db_adapter/snowflake.rb
@@ -28,7 +28,7 @@ class Webhookdb::DBAdapter::Snowflake < Webhookdb::DBAdapter
   end
 
   def create_index_sql(*)
-    raise NotImplementedError, "Snowflake does not support indices"
+    raise Webhookdb::InvalidPrecondition, "Snowflake does not support indices"
   end
 
   def create_table_sql(table, columns, if_not_exists: false, **)
@@ -129,9 +129,7 @@ class Webhookdb::DBAdapter::Snowflake < Webhookdb::DBAdapter
     conn.execute(statement)
   end
 
-  def identifier_quote_char
-    return ""
-  end
+  def identifier_quote_char = ""
 
   COLTYPE_MAP = {
     BIGINT => "bigint",

--- a/lib/webhookdb/icalendar.rb
+++ b/lib/webhookdb/icalendar.rb
@@ -7,6 +7,8 @@ module Webhookdb::Icalendar
   # If a manual backfill is attempted, direct customer to this url.
   DOCUMENTATION_URL = "https://docs.webhookdb.com/guides/icalendar/"
 
+  EVENT_REPLICATORS = ["icalendar_event_v1", "icalendar_event_v1_partitioned"].freeze
+
   include Appydays::Configurable
 
   configurable(:icalendar) do

--- a/lib/webhookdb/jobs/icalendar_delete_stale_cancelled_events.rb
+++ b/lib/webhookdb/jobs/icalendar_delete_stale_cancelled_events.rb
@@ -10,7 +10,7 @@ class Webhookdb::Jobs::IcalendarDeleteStaleCancelledEvents
   splay 120
 
   def _perform
-    Webhookdb::ServiceIntegration.where(service_name: "icalendar_event_v1").each do |sint|
+    Webhookdb::ServiceIntegration.where(service_name: Webhookdb::Icalendar::EVENT_REPLICATORS).each do |sint|
       self.with_log_tags(sint.log_tags) do
         deleted_rows = sint.replicator.stale_row_deleter.run
         self.set_job_tags("#{sint.organization.key}_#{sint.table_name}" => deleted_rows)

--- a/lib/webhookdb/organization/database_migration.rb
+++ b/lib/webhookdb/organization/database_migration.rb
@@ -112,7 +112,7 @@ class Webhookdb::Organization::DatabaseMigration < Webhookdb::Postgres::Model(:o
     tscol = svc.timestamp_column.name
     dstdb[svc.qualified_table_sequel_identifier].
       insert_conflict(
-        target: svc.remote_key_column.name,
+        target: svc._upsert_conflict_target,
         update_where: svc._update_where_expr,
       ).multi_insert(chunk)
     self.update(last_migrated_timestamp: chunk.last[tscol])

--- a/lib/webhookdb/replicator/icalendar_event_v1_partitioned.rb
+++ b/lib/webhookdb/replicator/icalendar_event_v1_partitioned.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "webhookdb/replicator/icalendar_event_v1"
+require "webhookdb/replicator/partitionable_mixin"
+
+class Webhookdb::Replicator::IcalendarEventV1Partitioned < Webhookdb::Replicator::IcalendarEventV1
+  include Webhookdb::Replicator::PartitionableMixin
+
+  # @return [Webhookdb::Replicator::Descriptor]
+  def self.descriptor
+    return Webhookdb::Replicator::Descriptor.new(
+      name: "icalendar_event_v1_partitioned",
+      ctor: ->(sint) { self.new(sint) },
+      dependency_descriptor: Webhookdb::Replicator::IcalendarCalendarV1.descriptor,
+      feature_roles: ["partitioning_beta"],
+      resource_name_singular: "iCalendar Event",
+      supports_webhooks: true,
+      description: "Individual events in an icalendar, using partitioned tables rather than one big table. " \
+                   "See icalendar_calendar_v1.",
+      api_docs_url: "https://icalendar.org/",
+    )
+  end
+
+  def _denormalized_columns
+    d = super
+    d << Webhookdb::Replicator::Column.new(:external_calendar_hash, INTEGER, optional: true)
+    return d
+  end
+
+  def partition_method = Webhookdb::DBAdapter::Partitioning::HASH
+  def partition_column_name = :external_calendar_hash
+  def partition_value(resource) = self._str2inthash(resource.fetch("calendar_external_id"))
+end

--- a/lib/webhookdb/replicator/icalendar_event_v1_partitioned.rb
+++ b/lib/webhookdb/replicator/icalendar_event_v1_partitioned.rb
@@ -23,11 +23,11 @@ class Webhookdb::Replicator::IcalendarEventV1Partitioned < Webhookdb::Replicator
 
   def _denormalized_columns
     d = super
-    d << Webhookdb::Replicator::Column.new(:external_calendar_hash, INTEGER, optional: true)
+    d << Webhookdb::Replicator::Column.new(:calendar_external_hash, INTEGER, optional: true)
     return d
   end
 
   def partition_method = Webhookdb::DBAdapter::Partitioning::HASH
-  def partition_column_name = :external_calendar_hash
+  def partition_column_name = :calendar_external_hash
   def partition_value(resource) = self._str2inthash(resource.fetch("calendar_external_id"))
 end

--- a/lib/webhookdb/replicator/partitionable_mixin.rb
+++ b/lib/webhookdb/replicator/partitionable_mixin.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Mixin for replicators that support partitioning.
+# Partitioning is currently in beta,
+# with the following limitations/context:
+#
+# - They cannot be created from the CLI.
+#   Because the partitions must be created during the CREATE TABLE call,
+#   the partition_value must be set immediately on creation,
+#   or CREATE TABLE must be deferred.
+# - CLI support would also require making sure this field isn't edited.
+#   This is an annoying change, so we're putting it off for now.
+# - Instead, partitioned replicators must be created in the console.
+# - The number of HASH partitions cannot be changed;
+#   there is no good way to handle this in Postgres so we don't bother here.
+# - RANGE partitions are not supported.
+#   We need to support creating the partition when the INSERT fails.
+#   But creating the partitioned table definition itself does work/has a shared behavior at least.
+# - Existing replicators cannot be converted to partitioned.
+#   This is theoretically possible, but it seems easier to just start over
+#   with a new replicator.
+# - Instead:
+#   - If this is a 'child' replicator, then create a new parent and this child,
+#     then copy over the parent data, either directly (for icalendar)
+#     or using HTTP requests (like with Plaid or Google) where more logic is required.
+#   - Otherwise, it'll depend on the replicator.
+#   - Then to switch clients using the old replicator, to the new replicator, you can:
+#     - Then turn off all workers.
+#     - Rename the new table to the old, and old table to the new.
+#     - Update the service integrations, so the old one points to the new table name and opaque id,
+#       and the new one points to the old table name and opaque id.
+#
+module Webhookdb::Replicator::PartitionableMixin
+  # The partition method, like Webhookdb::DBAdapter::Partitioning::HASH
+  def partition_method = raise NotImplementedError
+  # The partition column name.
+  # Must be present in +_denormalized_columns+.
+  # @return [Symbol]
+  def partition_column_name = raise NotImplementedError
+  # The value for the denormalized column. For HASH partitioning this would be an integer,
+  # for RANGE partitioning this could be a timestamp, etc.
+  # Takes the resource and returns the value.
+  def partition_value(_resource) = raise NotImplementedError
+
+  def partition? = true
+
+  def partitioning
+    return Webhookdb::DBAdapter::Partitioning.new(by: self.partition_method, column: self.partition_column_name)
+  end
+
+  def _prepare_for_insert(resource, event, request, enrichment)
+    h = super
+    h[self.partition_column_name] = self.partition_value(resource)
+    return h
+  end
+
+  def _upsert_conflict_target
+    return [self.partition_column_name, self._remote_key_column.name]
+  end
+
+  # Convert the given string into a stable MD5-derived hash
+  # that can be stored in a (signed, 4 bit) INTEGER column.
+  def _str2inthash(s)
+    # MD5 is 128 bits/16 bytes/32 hex chars (2 chars per byte).
+    # Integers are 32 bits/4 bytes/8 hex chars.
+    # Grab the first 8 chars and convert it to an integer.
+    unsigned_md5int = Digest::MD5.hexdigest(s)[..8].to_i(16)
+    # Then AND it with a 32 bit bitmask to make sure it fits in 32 bits
+    # (though I'm not entirely sure why the above doesn't result in 32 bits always).
+    unsigned_int32 = unsigned_md5int & 0xFFFFFFFF
+    # Convert it from unsigned (0 to 4.2B) to signed (-2.1B to 2.1B) by subtracting 2.1B
+    # (the max 2 byte integer), as opposed to a 4 byte integer which we're dealing with here.
+    signed_md5int = unsigned_int32 - MAX_16BIT_INT
+    return signed_md5int
+  end
+
+  MAX_16BIT_INT = 2**31
+end

--- a/lib/webhookdb/service_integration.rb
+++ b/lib/webhookdb/service_integration.rb
@@ -342,6 +342,11 @@ class Webhookdb::ServiceIntegration < Webhookdb::Postgres::Model(:service_integr
   # @!attribute skip_webhook_verification
   #   @return [Boolean] Set this to disable webhook verification on this integration.
   #                     Useful when replaying logged webhooks.
+
+  # @!attribute partition_value
+  #   @return [Integer] Value to control partitioning. For replicators that use hash partitioning,
+  #                     this defines the number of partitions. For other partition types, like range,
+  #                     the meaning of this value depends on the replicator itself.
 end
 
 # Table: service_integrations

--- a/spec/webhookdb/db_adapter_spec.rb
+++ b/spec/webhookdb/db_adapter_spec.rb
@@ -98,33 +98,33 @@ RSpec.describe Webhookdb::DBAdapter do
       end
     end
 
-    describe "column_create_sql" do
+    describe "create_column_sql" do
       it "returns the query" do
-        sql = ad.column_create_sql(col.new(name: :c1, type: coltype::TEXT))
+        sql = ad.create_column_sql(col.new(name: :c1, type: coltype::TEXT))
         expect(sql).to eq("c1 text")
       end
 
       it "works for primary keys" do
-        sql = ad.column_create_sql(col.new(name: :c1, type: coltype::BIGINT, pk: true))
+        sql = ad.create_column_sql(col.new(name: :c1, type: coltype::BIGINT, pk: true))
         expect(sql).to eq("c1 bigserial PRIMARY KEY")
-        sql = ad.column_create_sql(col.new(name: :c1, type: coltype::INTEGER, pk: true))
+        sql = ad.create_column_sql(col.new(name: :c1, type: coltype::INTEGER, pk: true))
         expect(sql).to eq("c1 serial PRIMARY KEY")
-        sql = ad.column_create_sql(col.new(name: :c1, type: coltype::TEXT, pk: true))
+        sql = ad.create_column_sql(col.new(name: :c1, type: coltype::TEXT, pk: true))
         expect(sql).to eq("c1 text PRIMARY KEY")
       end
 
       it "works for unique" do
-        sql = ad.column_create_sql(col.new(name: :c1, type: coltype::TEXT, unique: true))
+        sql = ad.create_column_sql(col.new(name: :c1, type: coltype::TEXT, unique: true))
         expect(sql).to eq("c1 text UNIQUE NOT NULL")
       end
 
       it "works for non-null" do
-        sql = ad.column_create_sql(col.new(name: :c1, type: coltype::TEXT, nullable: false))
+        sql = ad.create_column_sql(col.new(name: :c1, type: coltype::TEXT, nullable: false))
         expect(sql).to eq("c1 text NOT NULL")
       end
 
       it "escapes identifiers" do
-        sql = ad.column_create_sql(col.new(name: :from, type: coltype::TEXT))
+        sql = ad.create_column_sql(col.new(name: :from, type: coltype::TEXT))
         expect(sql).to eq("\"from\" text")
       end
     end

--- a/spec/webhookdb/db_adapter_spec.rb
+++ b/spec/webhookdb/db_adapter_spec.rb
@@ -3,6 +3,36 @@
 require "webhookdb/db_adapter"
 
 RSpec.describe Webhookdb::DBAdapter do
+  let(:sch) { described_class::Schema }
+  let(:tbl) { described_class::Table }
+  let(:col) { described_class::Column }
+  let(:ind) { described_class::Index }
+  let(:tbldesc) { described_class::TableDescriptor }
+  let(:coltype) { described_class::ColumnTypes }
+
+  mock_conn = Class.new(Webhookdb::DBAdapter::Connection) do
+    attr_reader :calls
+
+    def initialize
+      super
+      @calls = []
+    end
+
+    def execute(*a, **kw)
+      @calls << [:execute, a, kw]
+    end
+
+    alias_method :<<, :execute
+
+    def using
+      yield self
+    end
+
+    def copy_into(*a, **kw)
+      @calls << [:copy_into, a, kw]
+    end
+  end
+
   describe "adapter" do
     it "returns the pg adapter for postgres:// conn strings" do
       expect(described_class.adapter("postgres://")).to be_a(described_class::PG)
@@ -17,12 +47,6 @@ RSpec.describe Webhookdb::DBAdapter do
 
   describe "Webhookdb::DBAdapter::PG" do
     let(:ad) { described_class::PG.new }
-    let(:sch) { described_class::Schema }
-    let(:tbl) { described_class::Table }
-    let(:col) { described_class::Column }
-    let(:ind) { described_class::Index }
-    let(:tbldesc) { described_class::TableDescriptor }
-    let(:coltype) { described_class::ColumnTypes }
 
     describe "create_schema_sql" do
       it "returns the query" do
@@ -51,6 +75,103 @@ RSpec.describe Webhookdb::DBAdapter do
           if_not_exists: true,
         )
         expect(sql).to eq("CREATE TABLE IF NOT EXISTS blah.\"from\" (\n  c1 integer,\n  c2 text\n)")
+      end
+
+      describe "partitioning" do
+        it "creates a hash partitioned table" do
+          sql = ad.create_table_sql(
+            tbl.new(name: :foo),
+            [
+              col.new(name: :c1, type: coltype::INTEGER, pk: true),
+              col.new(name: :c2, type: coltype::TEXT, unique: true),
+            ],
+            partition: described_class::Partitioning.new(by: :hash, column: :c1),
+          )
+          expect(sql).to eq(<<~SQL.strip)
+            CREATE TABLE foo (
+              c1 serial,
+              c2 text,
+              PRIMARY KEY (c1),
+              UNIQUE (c1, c2)
+            )
+            PARTITION BY HASH (c1)
+          SQL
+        end
+
+        it "creates a range partitioned table" do
+          sql = ad.create_table_sql(
+            tbl.new(name: :foo),
+            [
+              col.new(name: :c1, type: coltype::INTEGER, pk: true),
+            ],
+            partition: described_class::Partitioning.new(by: :range, column: :c1),
+          )
+          expect(sql).to eq(<<~SQL.strip)
+            CREATE TABLE foo (
+              c1 serial,
+              PRIMARY KEY (c1)
+            )
+            PARTITION BY RANGE (c1)
+          SQL
+        end
+
+        it "errors for invalid partition by" do
+          expect do
+            ad.create_table_sql(
+              tbl.new(name: :foo),
+              [],
+              partition: described_class::Partitioning.new(by: :foo, column: :c1),
+            )
+          end.to raise_error(/unknown partition method/)
+        end
+
+        it "can partition on a column other than the pk" do
+          sql = ad.create_table_sql(
+            tbl.new(name: :foo),
+            [
+              col.new(name: :c1, type: coltype::BIGINT, pk: true),
+              col.new(name: :c2, type: coltype::BIGINT),
+            ],
+            partition: described_class::Partitioning.new(by: :hash, column: :c2),
+          )
+          expect(sql).to eq(<<~SQL.strip)
+            CREATE TABLE foo (
+              c1 bigserial,
+              c2 bigint,
+              PRIMARY KEY (c2, c1)
+            )
+            PARTITION BY HASH (c2)
+          SQL
+        end
+
+        it "can use a bigserial pk" do
+          sql = ad.create_table_sql(
+            tbl.new(name: :foo),
+            [
+              col.new(name: :c1, type: coltype::BIGINT, pk: true),
+            ],
+            partition: described_class::Partitioning.new(by: :hash, column: :c1),
+          )
+          expect(sql).to eq("CREATE TABLE foo (\n  c1 bigserial,\n  PRIMARY KEY (c1)\n)\nPARTITION BY HASH (c1)")
+        end
+
+        it "can use a non-serial pk" do
+          sql = ad.create_table_sql(
+            tbl.new(name: :foo),
+            [
+              col.new(name: :c1, type: coltype::TEXT, pk: true),
+            ],
+            partition: described_class::Partitioning.new(by: :hash, column: :c1),
+          )
+          # NOTE: This won't actually work for a partition, it is just here for better testing
+          # and to have a place to figure this out if needed in the future.
+          expect(sql).to eq("CREATE TABLE foo (\n  c1 text,\n  PRIMARY KEY (c1)\n)\nPARTITION BY HASH (c1)")
+        end
+
+        it "can create hash partitions" do
+          sql = ad.create_hash_partition_sql(tbl.new(name: :foo), 2, 1)
+          expect(sql).to eq("CREATE TABLE foo_1 PARTITION OF foo FOR VALUES WITH (MODULUS 2, REMAINDER 1)")
+        end
       end
     end
 
@@ -127,6 +248,88 @@ RSpec.describe Webhookdb::DBAdapter do
         sql = ad.create_column_sql(col.new(name: :from, type: coltype::TEXT))
         expect(sql).to eq("\"from\" text")
       end
+    end
+
+    describe "add_column_sql" do
+      let(:t) { tbl.new(name: :tbl) }
+
+      it "returns the query" do
+        sql = ad.add_column_sql(t, col.new(name: :c1, type: coltype::TEXT))
+        expect(sql).to eq("ALTER TABLE tbl ADD COLUMN c1 text")
+
+        sql = ad.add_column_sql(t, col.new(name: :c1, type: coltype::TEXT), if_not_exists: true)
+        expect(sql).to eq("ALTER TABLE tbl ADD COLUMN IF NOT EXISTS c1 text")
+      end
+    end
+
+    it "can verify its connection" do
+      expect { ad.verify_connection(ENV.fetch("DATABASE_URL", nil)) }.to_not raise_error
+    end
+
+    it "can merge from csv" do
+      expect(SecureRandom).to receive(:hex).and_return("0420bff4")
+      c = mock_conn.new
+      ad.merge_from_csv(c, "xyz", tbl.new(name: :foo), :mypk, [:x, :y])
+      # rubocop:disable Layout/LineLength
+      expect(c.calls).to eq(
+        [
+          [:execute, ["CREATE TEMP TABLE foo_staging_0420bff4 (LIKE foo)"], {}],
+          [:copy_into, [:foo_staging_0420bff4], {data: "xyz", options: "DELIMITER ',', HEADER true, FORMAT csv"}],
+          [:execute, ["UPDATE foo AS tgt\nSET x = src.x, y = src.y FROM\n(SELECT * FROM foo_staging_0420bff4 WHERE mypk IN (SELECT mypk FROM foo)) src\nWHERE tgt.mypk = src.mypk;\n\nINSERT INTO foo SELECT * FROM foo_staging_0420bff4 WHERE mypk NOT IN (SELECT mypk FROM foo);"], {}],
+        ],
+      )
+      # rubocop:enable Layout/LineLength
+    end
+  end
+
+  describe "Webhookdb::DBAdapter::Snowflake" do
+    let(:ad) { described_class::Snowflake.new }
+
+    it "can create a table" do
+      sql = ad.create_table_sql(
+        tbl.new(name: :foo, schema: sch.new(name: :bar)),
+        [col.new(name: :c1, type: coltype::INTEGER)],
+      )
+      expect(sql).to eq("CREATE TABLE bar.foo (\n  c1 integer\n)")
+    end
+
+    it "raises if trying to create an index" do
+      expect { ad.create_index_sql }.to raise_error(/Snowflake does not support indices/)
+    end
+
+    it "executes using the cli" do
+      c = ad.connection("x://y.z")
+      expect(Webhookdb::Snowflake).to receive(:run_cli).with("x://y.z", "SELECT 2")
+      c.execute("SELECT 2")
+    end
+
+    it "can verify its connection" do
+      expect(Webhookdb::Snowflake).to receive(:run_cli).with("x://y.z", "SELECT 1")
+      ad.verify_connection("x://y.z")
+    end
+
+    it "can merge from csv" do
+      c = mock_conn.new
+      t = tbl.new(name: :foo, schema: sch.new(name: :bar))
+      pkcol = col.new(name: :mypk, type: coltype::INTEGER)
+      copycols = [
+        col.new(name: :c1, type: coltype::INTEGER),
+        col.new(name: :c2, type: coltype::INTEGER),
+      ]
+      tmp = Tempfile.new
+      ad.merge_from_csv(c, tmp, t, pkcol, copycols)
+      expect(c.calls.to_s).to include("CREATE STAGE bar.whdb_tempstage_")
+    end
+
+    it "can add a new column to a table" do
+      sql = ad.add_column_sql(tbl.new(name: :foo), col.new(name: :bar, type: coltype::INTEGER))
+      expect(sql).to eq("ALTER TABLE foo ADD COLUMN bar integer")
+    end
+
+    it "can add a column with if_not_exists" do
+      t = tbl.new(name: :foo, schema: sch.new(name: :bar))
+      sql = ad.add_column_sql(t, col.new(name: :bar, type: coltype::INTEGER), if_not_exists: true)
+      expect(sql).to include("EXECUTE IMMEDIATE $$")
     end
   end
 

--- a/spec/webhookdb/replicator/base_stale_row_deleter_spec.rb
+++ b/spec/webhookdb/replicator/base_stale_row_deleter_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe Webhookdb::Replicator::BaseStaleRowDeleter, :db do
     )
   end
 
+  it "does not set autovacuum on partitioned tables" do
+    expect(svc).to receive(:partition?).twice.and_return(true)
+    logs = capture_logs_from(Webhookdb.logger, level: :debug, formatter: :json) do
+      svc.stale_row_deleter.run
+    end
+    expect(logs).to_not have_a_line_matching(/autovacuum_enabled/)
+  end
+
   it "handles no rows (to delete, or at all)" do
     expect do
       svc.stale_row_deleter.run

--- a/spec/webhookdb/replicator/fake_spec.rb
+++ b/spec/webhookdb/replicator/fake_spec.rb
@@ -792,6 +792,13 @@ or leave blank to choose the first option.
         expect(result).to eq(child_sint)
       end
 
+      it "can search an array of names" do
+        child_sint = Webhookdb::Fixtures.service_integration.depending_on(root_sint).create
+        expect(root_sint.dependents.first).to eq(child_sint)
+        result = root_sint.replicator.find_dependent(["abc", "fake_v1"])
+        expect(result).to eq(child_sint)
+      end
+
       it "errors if there is no dependent integration with given service name" do
         expect(root_sint.replicator.find_dependent("fake_v2")).to be_nil
         expect do
@@ -921,6 +928,36 @@ or leave blank to choose the first option.
           my_id: "x",
         ),
       )
+    end
+  end
+
+  describe "partitioning" do
+    describe Webhookdb::Replicator::FakeHashPartition do
+      let(:sint) { Webhookdb::Fixtures.service_integration.create(service_name: "fake_hash_partition_v1") }
+      let(:svc) { sint.replicator }
+
+      it_behaves_like "a replicator that supports hash partitioning" do
+        def body(i)
+          {
+            "my_id" => i.to_s,
+            "at" => "Thu, 30 Jul 2015 21:12:33 +0000",
+          }
+        end
+      end
+    end
+
+    describe Webhookdb::Replicator::FakeRangePartition do
+      let(:sint) { Webhookdb::Fixtures.service_integration.create(service_name: "fake_range_partition_v1") }
+      let(:svc) { sint.replicator }
+
+      it_behaves_like "a replicator that supports range partitioning" do
+        def body(i)
+          {
+            "my_id" => i.to_s,
+            "at" => "Thu, #{i + 1} Jul 2015 21:12:33 +0000",
+          }
+        end
+      end
     end
   end
 end

--- a/spec/webhookdb/replicator/icalendar_event_v1_partitioned_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_event_v1_partitioned_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Webhookdb::Replicator::IcalendarEventV1Partitioned, :db do
         include(
           calendar_external_id: "abc",
           compound_identity: "abc-c7614cff-3549-4a00-9152-d25cc1fe077d",
-          external_calendar_hash: -2_146_104_957,
+          calendar_external_hash: -2_146_104_957,
         ),
       )
     end

--- a/spec/webhookdb/replicator/icalendar_event_v1_partitioned_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_event_v1_partitioned_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Webhookdb::Replicator::IcalendarEventV1Partitioned, :db do
   let(:fac) { Webhookdb::Fixtures.service_integration(organization: org) }
   let(:calendar_sint) { fac.create(service_name: "icalendar_calendar_v1") }
   let(:calendar_svc) { calendar_sint.replicator }
-  let(:sint) { fac.depending_on(calendar_sint).create(service_name: "icalendar_event_v1_partitioned").refresh }
+  let(:sint) do
+    fac.depending_on(calendar_sint).create(service_name: "icalendar_event_v1_partitioned", partition_value: 200)
+  end
   let(:svc) { sint.replicator }
 
   it_behaves_like "a replicator that supports hash partitioning" do
@@ -23,6 +25,73 @@ RSpec.describe Webhookdb::Replicator::IcalendarEventV1Partitioned, :db do
       h["calendar_external_id"] = i.to_s
       h["row_updated_at"] = Time.now.iso8601
       return h
+    end
+  end
+
+  def insert_calendar_row(**more)
+    calendar_svc.admin_dataset do |ds|
+      inserted = ds.returning(Sequel.lit("*")).
+        insert(
+          data: "{}",
+          row_created_at: Time.now,
+          row_updated_at: Time.now,
+          **more,
+        )
+      return inserted.first
+    end
+  end
+
+  describe "sync_row" do
+    before(:each) do
+      org.prepare_database_connections
+      calendar_svc.create_table
+      svc.create_table
+    end
+
+    after(:each) do
+      org.remove_related_database
+    end
+
+    it "upserts each vevent in the url, and stores meta about the fetch" do
+      body = <<~ICAL
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        PRODID:-//ZContent.net//Zap Calendar 1.0//EN
+        CALSCALE:GREGORIAN
+        METHOD:PUBLISH
+        BEGIN:VEVENT
+        SUMMARY:Abraham Lincoln
+        UID:c7614cff-3549-4a00-9152-d25cc1fe077d
+        SEQUENCE:0
+        STATUS:CONFIRMED
+        DTSTART:20080212
+        DTEND:20080213
+        DTSTAMP:20150421T141403
+        END:VEVENT
+        END:VCALENDAR
+      ICAL
+      req = stub_request(:get, "https://feed.me").
+        and_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "text/calendar",
+            "Content-Length" => body.size.to_s,
+            "Etag" => "somevalue",
+          },
+          body:,
+        )
+      row = insert_calendar_row(ics_url: "https://feed.me", external_id: "abc")
+      calendar_svc.sync_row(row)
+      calendar_svc.sync_row(row)
+      expect(req).to have_been_made.times(2)
+      expect(calendar_svc.admin_dataset(&:all)).to contain_exactly(include(last_synced_at: match_time(:now)))
+      expect(svc.admin_dataset(&:all)).to contain_exactly(
+        include(
+          calendar_external_id: "abc",
+          compound_identity: "abc-c7614cff-3549-4a00-9152-d25cc1fe077d",
+          external_calendar_hash: -2_146_104_957,
+        ),
+      )
     end
   end
 end

--- a/spec/webhookdb/replicator/icalendar_event_v1_partitioned_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_event_v1_partitioned_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "support/shared_examples_for_replicators"
+
+RSpec.describe Webhookdb::Replicator::IcalendarEventV1Partitioned, :db do
+  let(:org) { Webhookdb::Fixtures.organization.create }
+  let(:fac) { Webhookdb::Fixtures.service_integration(organization: org) }
+  let(:calendar_sint) { fac.create(service_name: "icalendar_calendar_v1") }
+  let(:calendar_svc) { calendar_sint.replicator }
+  let(:sint) { fac.depending_on(calendar_sint).create(service_name: "icalendar_event_v1_partitioned").refresh }
+  let(:svc) { sint.replicator }
+
+  it_behaves_like "a replicator that supports hash partitioning" do
+    def body(i)
+      s = <<~ICAL
+        BEGIN:VEVENT
+        DTSTART:20200220T170000Z
+        DTEND:20190820T190000Z
+        UID:79396C44-9EA7-4EF0-A99F-5EFCE7764CFE
+        END:VEVENT
+      ICAL
+      h = described_class.vevent_to_hash(s.lines)
+      h["calendar_external_id"] = i.to_s
+      h["row_updated_at"] = Time.now.iso8601
+      return h
+    end
+  end
+end


### PR DESCRIPTION
Add our first partitioned replicator,
icalendar_event_v1_partitioned, which uses HASH partitioning on the calendar_external_id table.

Add a mixin to make this easier for other replicators.

Adjusts code throughout the app to make partitioning possible, along with initial RANGE partition support.

Update code that only looked for icalendar_event_v1, and make it also look for icalendar_event_v1_partitioned.

NOTE: partitioned replicators are still in beta while their UX is hammered out- the partitions need to be set up when the replicator is created, which means more state machine work. But these are a 'pro' feature, so creating them from the console for now isn't the end of the world.

