### PR TITLE
Support adding indices to index tables

### DIFF
--- a/lib/webhookdb/db_adapter.rb
+++ b/lib/webhookdb/db_adapter.rb
@@ -2,6 +2,7 @@
 
 class Webhookdb::DBAdapter
   require "webhookdb/db_adapter/column_types"
+  require "webhookdb/db_adapter/partition"
   require "webhookdb/db_adapter/partitioning"
 
   class UnsupportedAdapter < Webhookdb::ProgrammingError; end
@@ -170,6 +171,16 @@ class Webhookdb::DBAdapter
   # @return [String]
   def create_index_sql(index, concurrently:)
     raise NotImplementedError
+  end
+
+  # Create indices, including for partitions.
+  # By default, just call create_index_sql and return it in a single-item array.
+  # Override if creating indices while using partitions requires extra logic.
+  # @param partitions [Array<Webhookdb::DBAdapter::Partition>]
+  # @return [Array<String>]
+  def create_index_sqls(index, concurrently:, partitions: [])
+    _ = partitions
+    return [self.create_index_sql(index, concurrently:)]
   end
 
   # @param column [Column] The column to create SQL for.

--- a/lib/webhookdb/db_adapter/partition.rb
+++ b/lib/webhookdb/db_adapter/partition.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Webhookdb::DBAdapter::Partition < Webhookdb::TypedStruct
+  attr_reader :parent_table, :partition_name, :suffix
+
+  def initialize(**kwargs)
+    super
+    self.typecheck!(:parent_table, Webhookdb::DBAdapter::Table)
+    self.typecheck!(:partition_name, Symbol)
+    self.typecheck!(:suffix, Symbol)
+  end
+
+  def partition_table = Webhookdb::DBAdapter::Table.new(name: self.partition_name, schema: self.parent_table.schema)
+end

--- a/lib/webhookdb/replicator/fake.rb
+++ b/lib/webhookdb/replicator/fake.rb
@@ -12,6 +12,7 @@ class Webhookdb::Replicator::Fake < Webhookdb::Replicator::Base
   singleton_attr_accessor :process_webhooks_synchronously
   singleton_attr_accessor :obfuscate_headers_for_logging
   singleton_attr_accessor :requires_sequence
+  singleton_attr_accessor :extra_index_specs
 
   def self._descriptor(**kw)
     clsname = self.name.split("::").last
@@ -40,6 +41,8 @@ class Webhookdb::Replicator::Fake < Webhookdb::Replicator::Base
     self.descendants&.each do |d|
       d.reset if d.respond_to?(:reset)
     end
+    self.extra_index_specs = nil
+    self.descendants&.each(&:reset)
   end
 
   def self.stub_backfill_request(items, status: 200)
@@ -130,6 +133,8 @@ class Webhookdb::Replicator::Fake < Webhookdb::Replicator::Base
   def requires_sequence?
     return self.class.requires_sequence
   end
+
+  def _extra_index_specs = super + (self.class.extra_index_specs || [])
 
   def dispatch_request_to(request)
     return self.class.dispatch_request_to_hook.call(request) if self.class.dispatch_request_to_hook


### PR DESCRIPTION
We use CREATE INDEX CONCURRENTLY, which doesn't work with partitioned tables.

Instead, we need to create the index concurrently on each partition, and then attach them to the 'parent' index.

Massages dbadapter to support this better.

Add a structured `Partition` type,
to describe a partition (parent table, name, suffix).

Add helper to gather existing partitions.

Add helper to align partition names to the parent table name, which is necessary after renaming a table with partitions (may be automated in the future after renaming a table).
