### PR TITLE
Fix autoscaler bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ PATH
       sequel_pg (~> 1.17)
       sequel_postgresql_triggers (~> 1.6)
       sidekiq (~> 6)
-      sidekiq-amigo (~> 1.8)
+      sidekiq-amigo (~> 1.9)
       sidekiq-cron (~> 1.12)
       slack-notifier (~> 2.4)
       stripe (~> 10.15)
@@ -118,8 +118,8 @@ GEM
     clavius (1.0.4)
     clipboard (1.4.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -198,7 +198,7 @@ GEM
       multi_xml (>= 0.5.2)
     httpx (1.4.0)
       http-2 (>= 1.0.0)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     inflecto (0.0.2)
     jmespath (1.6.2)
@@ -210,7 +210,7 @@ GEM
       bigdecimal
       strscan
     loggability (0.18.2)
-    logger (1.6.4)
+    logger (1.6.5)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -377,7 +377,7 @@ GEM
       connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
-    sidekiq-amigo (1.8.0)
+    sidekiq-amigo (1.9.0)
       sidekiq (~> 6)
       sidekiq-cron (~> 1)
     sidekiq-cron (1.12.0)

--- a/lib/webhookdb/spec_helpers/async.rb
+++ b/lib/webhookdb/spec_helpers/async.rb
@@ -22,10 +22,6 @@ module Webhookdb::SpecHelpers::Async
         Webhookdb::Slack.http_client = Webhookdb::Slack::NoOpHttpClient.new
         Webhookdb::Slack.suppress_all = false
       end
-      if example.metadata[:sentry]
-        Webhookdb::Sentry.dsn = "http://public:secret@not-really-sentry.nope/someproject"
-        Webhookdb::Sentry.run_after_configured_hooks
-      end
     end
 
     context.after(:each) do |example|

--- a/lib/webhookdb/spec_helpers/sentry.rb
+++ b/lib/webhookdb/spec_helpers/sentry.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "webhookdb/spec_helpers"
+require "webhookdb/sentry"
+
+module Webhookdb::SpecHelpers::Sentry
+  def self.included(context)
+    context.before(:each) do |example|
+      if example.metadata[:sentry]
+        # We need to fake doing what Sentry would be doing for initialization,
+        # so we can assert it has the right data in its scope.
+        Webhookdb::Sentry.dsn = "https://public:secret@test-sentry.webhookdb.com/whdb"
+        hub = Sentry::Hub.new(
+          Sentry::Client.new(Sentry::Configuration.new),
+          Sentry::Scope.new,
+        )
+        expect(Sentry).to_not be_initialized
+        Sentry.instance_variable_set(:@main_hub, hub)
+        expect(Sentry).to be_initialized
+      end
+    end
+
+    context.after(:each) do |example|
+      if example.metadata[:sentry]
+        Webhookdb::Sentry.reset_configuration
+        expect(Sentry).to_not be_initialized
+      end
+    end
+
+    super
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,6 @@ require "appydays/loggable/spec_helpers"
 
 require "webhookdb"
 require "webhookdb/spec_helpers"
-require "webhookdb/spec_helpers/postgres"
 require "webhookdb/fixtures"
 
 Webhookdb.load_app
@@ -74,7 +73,10 @@ RSpec.configure do |config|
     config.include(Webhookdb::SpecHelpers::Async)
     require "webhookdb/spec_helpers/message"
     config.include(Webhookdb::SpecHelpers::Message)
+    require "webhookdb/spec_helpers/postgres"
     config.include(Webhookdb::SpecHelpers::Postgres)
+    require "webhookdb/spec_helpers/sentry"
+    config.include(Webhookdb::SpecHelpers::Sentry)
     require "webhookdb/spec_helpers/service"
     config.include(Webhookdb::SpecHelpers::Service)
     require "webhookdb/spec_helpers/whdb"

--- a/spec/webhookdb/service_spec.rb
+++ b/spec/webhookdb/service_spec.rb
@@ -524,25 +524,7 @@ RSpec.describe Webhookdb::Service, :db do
     )
   end
 
-  describe "Sentry integration" do
-    before(:each) do
-      # We need to fake doing what Sentry would be doing for initialization,
-      # so we can assert it has the right data in its scope.
-      Webhookdb::Sentry.dsn = "foo"
-      hub = Sentry::Hub.new(
-        Sentry::Client.new(Sentry::Configuration.new),
-        Sentry::Scope.new,
-      )
-      expect(Sentry).to_not be_initialized
-      Sentry.instance_variable_set(:@main_hub, hub)
-      expect(Sentry).to be_initialized
-    end
-
-    after(:each) do
-      Webhookdb::Sentry.reset_configuration
-      expect(Sentry).to_not be_initialized
-    end
-
+  describe "Sentry integration", :sentry do
     it "reports errors to Sentry if devmode is off and Sentry is enabled" do
       described_class.devmode = false
       expect(Sentry).to receive(:capture_exception).

--- a/webhookdb.gemspec
+++ b/webhookdb.gemspec
@@ -82,7 +82,7 @@ Gem::Specification.new do |s|
   s.add_dependency("sequel-soft-deletes", "~> 0.1")
   s.add_dependency("sequel-tstzrange-fields", "~> 0.2")
   s.add_dependency("sidekiq", "~> 6")
-  s.add_dependency("sidekiq-amigo", "~> 1.8")
+  s.add_dependency("sidekiq-amigo", "~> 1.9")
   s.add_dependency("sidekiq-cron", "~> 1.12")
   s.add_dependency("slack-notifier", "~> 2.4")
   s.add_dependency("stripe", "~> 10.15")


### PR DESCRIPTION
In 6d00be465ea741a9460f915a2db0311fd6212cf1, I changed how we report high latency queues to Sentry. There was a mistake causing an undefined local (`kw`).

This wasn't caught in tests, because we used `scope&.set_tags(*kw)`. But `scope` was nil because Sentry wasn't configured for tests, so the `set_tags` call wasn't made and the invalid local wasn't evaluated.

This wasn't reported to Sentry because it happened in a background thread, which Sentry doesn't listen for errors in.

This change does the following:

- Fixes the bug
- Uses the new `on_unhandled_exception` argument to `Amigo::Autoscaler`, which means we will report on unhandled exceptions.
- Tests the fix and that we're reporting unhandled errors correctly.
- Moves Sentry test helpers into a spec helper, since full Sentry test configuring is nontrivial (need to make sure there is a current hub in order for scope to work, for example).
