### PR TITLE
Improve icalendar stale row deleter

### DIFF
--- a/lib/webhookdb/jobs/icalendar_delete_stale_cancelled_events.rb
+++ b/lib/webhookdb/jobs/icalendar_delete_stale_cancelled_events.rb
@@ -9,11 +9,15 @@ class Webhookdb::Jobs::IcalendarDeleteStaleCancelledEvents
   cron "37 7 * * *" # Once a day
   splay 120
 
+  ADVISORY_LOCK_ID = 1_236_432_568
+
   def _perform
     Webhookdb::ServiceIntegration.where(service_name: Webhookdb::Icalendar::EVENT_REPLICATORS).each do |sint|
       self.with_log_tags(sint.log_tags) do
-        deleted_rows = sint.replicator.stale_row_deleter.run
-        self.set_job_tags("#{sint.organization.key}_#{sint.table_name}" => deleted_rows)
+        sint.replicator.with_advisory_lock(ADVISORY_LOCK_ID) do
+          deleted_rows = sint.replicator.stale_row_deleter.run
+          self.set_job_tags("#{sint.organization.key}_#{sint.table_name}" => deleted_rows)
+        end
       end
     end
   end

--- a/lib/webhookdb/replicator/base.rb
+++ b/lib/webhookdb/replicator/base.rb
@@ -969,10 +969,10 @@ for information on how to refresh data.)
   # - The table OID for this replicator
   # - The given key
   #
-  # Note this this establishes a new DB connection for the advisory lock;
+  # Note this establishes a new DB connection for the advisory lock;
   # we have had issues with advisory locks on reused connections,
   # and this is safer than having a lock that is never released.
-  protected def with_advisory_lock(key, &)
+  def with_advisory_lock(key, &)
     url = self.service_integration.organization.admin_connection_url_raw
     got = nil
     Webhookdb::Dbutil.borrow_conn(url) do |conn|

--- a/lib/webhookdb/replicator/icalendar_event_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_event_v1.rb
@@ -216,6 +216,10 @@ class Webhookdb::Replicator::IcalendarEventV1 < Webhookdb::Replicator::Base
         columns: [:calendar_external_id, :start_date, :end_date],
         where: Sequel[:status].is_distinct_from("CANCELLED") & (Sequel[:start_date] !~ nil),
       ),
+      Webhookdb::Replicator::IndexSpec.new(
+        columns: [:row_updated_at],
+        where: Sequel[status: "CANCELLED"],
+      ),
     ]
   end
 

--- a/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
+++ b/spec/webhookdb/replicator/icalendar_calendar_v1_spec.rb
@@ -1856,13 +1856,15 @@ RSpec.describe Webhookdb::Replicator::IcalendarCalendarV1, :db do
       let(:fn) { "invalid_bymonthyearday.ics" }
 
       it "returns an array of calendars" do
-        parsed = all_events
-        # Because we project '5 years' into the future, we can end up with 36 or more events
+        # Because we project '5 years' into the future, we can end up with more than 36 events at times
         # (3102AFB1-1FE8-49A1-BBB2-20965DFD44C9-30 is the extra event).
         # Use Timecop.travel('2024-08-10') to see 36,
         # Timecop.travel('2024-08-16') to see 37,
         # Timecop.travel('2024-12-03') to see 38.
-        expect(parsed).to have_length(be_between(36, 38))
+        # Timecop.travel('2025-12-03') to see 39.
+        # Rather than having a flaky or imprecise spec, we use timecop to get a consistent result.
+        parsed = Timecop.travel(Date.new(2024, 8, 1)) { all_events }
+        expect(parsed).to have_length(36)
         expect(parsed).to include(
           hash_including("DTSTART" => {"v" => "20220514"}),
           hash_including("DTSTART" => {"v" => "20220814"}),


### PR DESCRIPTION
Advisory lock around each deletion.
If multiple DELETEs are called at the same time,
we run into massive IO issues.

Add a conditional index to optimize for this DELETE, `row_updated_at WHERE status = 'CANCELLED'`.
It is relatively small and should help speed up deletes.
