### PR TITLE
Speed up stale row deletion on partitioned tables

### DIFF
--- a/lib/webhookdb/replicator/fake.rb
+++ b/lib/webhookdb/replicator/fake.rb
@@ -419,6 +419,16 @@ class Webhookdb::Replicator::FakeStaleRow < Webhookdb::Replicator::Fake
   def stale_row_deleter = StaleRowDeleter.new(self)
 end
 
+class Webhookdb::Replicator::FakeStaleRowPartitioned < Webhookdb::Replicator::FakeStaleRow
+  include Webhookdb::Replicator::PartitionableMixin
+
+  def self.descriptor = self._descriptor
+
+  def partition_method = Webhookdb::DBAdapter::Partitioning::HASH
+  def partition_column_name = :textcol
+  def partition_value(r) = r.fetch("textcol")
+end
+
 class Webhookdb::Replicator::FakeWithWatchChannel < Webhookdb::Replicator::Fake
   singleton_attr_accessor :renew_calls
 

--- a/spec/webhookdb/replicator/fake_spec.rb
+++ b/spec/webhookdb/replicator/fake_spec.rb
@@ -1015,12 +1015,15 @@ or leave blank to choose the first option.
       it "can align partition names to a different parent table name" do
         sint.update(table_name: "original")
         sint.replicator.create_table
+        getnames = lambda do
+          sint.replicator.admin_dataset { |ds| sint.replicator.existing_partitions(ds.db).map(&:partition_name) }
+        end
         # rubocop:disable Naming/VariableNumber
-        expect(sint.replicator.existing_partitions.map(&:partition_name)).to contain_exactly(:original_0, :original_1)
+        expect(getnames.call).to contain_exactly(:original_0, :original_1)
         sint.rename_table(to: "other")
-        expect(sint.replicator.existing_partitions.map(&:partition_name)).to contain_exactly(:original_0, :original_1)
+        expect(getnames.call).to contain_exactly(:original_0, :original_1)
         sint.replicator.partition_align_name
-        expect(sint.replicator.existing_partitions.map(&:partition_name)).to contain_exactly(:other_0, :other_1)
+        expect(getnames.call).to contain_exactly(:other_0, :other_1)
         # rubocop:enable Naming/VariableNumber
       end
 


### PR DESCRIPTION
If the replicator is partitioned, we need to delete stale rows on partition separately. We DELETE with a LIMIT in chunks, but when we run this on the main table, it'll run the query on every partition BEFORE applying the limit. You'll see this manifest with speed, but also the planner using a sequential scan for the delete, rather than hitting an index. Instead, DELETE from each partition in chunks, which will use the indices, and apply the limit properly.

