### PR TITLE
Advisory locks handle bigint second keys

### DIFF
--- a/lib/sequel/advisory_lock.rb
+++ b/lib/sequel/advisory_lock.rb
@@ -3,6 +3,10 @@
 require "sequel"
 
 class Sequel::AdvisoryLock
+  MAX_INT = 2_147_483_647
+  MIN_INT = -2_147_483_648
+  MAX_UINT = 4_294_967_295
+
   def initialize(db, key_or_key1, key2=nil, shared: false, xact: false)
     @db = db
     xstr = xact ? "_xact" : ""


### PR DESCRIPTION
Fixes https://lithic-technology.sentry.io/issues/6651707636

If using `with_advisory_lock(row_pk_that_is_bigint)`, we'd get an error.
It should be pretty safe to use an int instead.

