### PR TITLE
Add integration-specific job semaphores

### DIFF
--- a/db/migrations/053_integration_semaphore.rb
+++ b/db/migrations/053_integration_semaphore.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    alter_table(:service_integrations) do
+      add_column :integration_job_semaphore_size, :int, null: false, default: 0
+    end
+    alter_table(:organizations) do
+      rename_column :job_semaphore_size, :organization_job_semaphore_size
+    end
+  end
+end

--- a/lib/webhookdb/jobs/icalendar_sync.rb
+++ b/lib/webhookdb/jobs/icalendar_sync.rb
@@ -28,8 +28,8 @@ class Webhookdb::Jobs::IcalendarSync
     @sint = self.lookup_model(Webhookdb::ServiceIntegration, sint_id)
   end
 
-  def semaphore_key = "semaphore-icalendarsync-#{@sint.organization_id}"
-  def semaphore_size = @sint.organization.job_semaphore_size
+  def semaphore_key = "semaphore-icalendarsync-#{@sint.job_semaphore_identifier}"
+  def semaphore_size = @sint.job_semaphore_size
   def semaphore_expiry = 15.minutes
   def semaphore_backoff = 60 + (rand * 30)
 end

--- a/lib/webhookdb/jobs/process_webhook.rb
+++ b/lib/webhookdb/jobs/process_webhook.rb
@@ -14,8 +14,10 @@ class Webhookdb::Jobs::ProcessWebhook
   on "webhookdb.serviceintegration.webhook"
   sidekiq_options queue: "webhook" # This is usually overridden.
 
-  def semaphore_expiry = 5.minutes.to_i
   def dependent_queues = ["critical"]
+  def semaphore_expiry = 5.minutes.to_i
+  def semaphore_key = "semaphore-procwebhook-#{@sint.job_semaphore_identifier}"
+  def semaphore_size = @sint.job_semaphore_size
 
   def before_perform(*args)
     event = Amigo::Event.from_json(args[0])
@@ -34,13 +36,5 @@ class Webhookdb::Jobs::ProcessWebhook
       method: kw.fetch(:request_method),
     )
     svc.upsert_webhook(req)
-  end
-
-  def semaphore_key
-    return "semaphore-procwebhook-#{@sint.organization_id}"
-  end
-
-  def semaphore_size
-    return @sint.organization.job_semaphore_size
   end
 end

--- a/lib/webhookdb/organization.rb
+++ b/lib/webhookdb/organization.rb
@@ -551,7 +551,7 @@ class Webhookdb::Organization < Webhookdb::Postgres::Model(:organizations)
   # @!attribute replication_schema
   #   @return [String]
 
-  # @!attribute job_semaphore_size
+  # @!attribute organization_job_semaphore_size
   #   @return [Integer]
 
   # @!attribute minimum_sync_seconds

--- a/spec/webhookdb/async/jobs_spec.rb
+++ b/spec/webhookdb/async/jobs_spec.rb
@@ -582,10 +582,10 @@ RSpec.describe "webhookdb async jobs", :async, :db, :do_not_defer_events, :no_tr
 
     it "can calculate semaphore details" do
       sint = Webhookdb::Fixtures.service_integration.create
-      sint.organization.update(job_semaphore_size: 6)
+      sint.update(integration_job_semaphore_size: 6)
       j = Webhookdb::Jobs::ProcessWebhook.new
       j.before_perform({"id" => "1", "name" => "topic", "payload" => [sint.id]})
-      expect(j).to have_attributes(semaphore_key: "semaphore-procwebhook-#{sint.organization_id}", semaphore_size: 6)
+      expect(j).to have_attributes(semaphore_key: "semaphore-procwebhook-sint-#{sint.id}", semaphore_size: 6)
     end
   end
 

--- a/spec/webhookdb/service_integration_spec.rb
+++ b/spec/webhookdb/service_integration_spec.rb
@@ -271,4 +271,14 @@ RSpec.describe "Webhookdb::ServiceIntegration", :db do
       expect(a_a_a_a.recursive_dependencies).to have_same_ids_as(a_a_a, a_a, a).ordered
     end
   end
+
+  describe "job_semaphore_size" do
+    it "uses the service integration semaphore size if non-zero, and falls back to the organization" do
+      sint = Webhookdb::Fixtures.service_integration.create
+      sint.organization.organization_job_semaphore_size = 9
+      expect(sint).to have_attributes(job_semaphore_size: 9, job_semaphore_identifier: "org-#{sint.organization_id}")
+      sint.integration_job_semaphore_size = 5
+      expect(sint).to have_attributes(job_semaphore_size: 5, job_semaphore_identifier: "sint-#{sint.id}")
+    end
+  end
 end


### PR DESCRIPTION
We need to migrate from a non-partitioned to a partitioned google calendar events table, which is billions of rows (or very large, in any case).

If we just allow this to start backfilling, it will saturate all the workers for the org, and also consume a ton of DB CPU (though everything works). To prevent this from happening, we can semaphore the integration in particular.
