### PR TITLE
Fix connection errors during body reads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ group :test do
   gem "rubocop-sequel", "~> 0.3", require: false
   gem "simplecov", "~> 0.22", require: false
   gem "simplecov-cobertura", "~> 2.1"
-  gem "thin"
   gem "timecop", "~> 0.9"
   gem "webmock", "~> 3.19"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,6 @@ GEM
     css_parser (1.21.0)
       addressable
     csv (3.3.2)
-    daemons (1.4.1)
     date (3.4.1)
     diff-lcs (1.5.1)
     docile (1.4.1)
@@ -155,7 +154,6 @@ GEM
     erubis (2.7.0)
     et-orbi (1.2.11)
       tzinfo
-    eventmachine (1.2.7)
     excon (1.2.3)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
@@ -415,10 +413,6 @@ GEM
     statsd-ruby (1.5.0)
     stripe (10.15.0)
     strscan (3.1.2)
-    thin (1.8.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     timecop (0.9.10)
     timeout (0.4.3)
     tzinfo (2.0.6)
@@ -456,7 +450,6 @@ DEPENDENCIES
   rubocop-sequel (~> 0.3)
   simplecov (~> 0.22)
   simplecov-cobertura (~> 2.1)
-  thin
   timecop (~> 0.9)
   webhookdb!
   webmock (~> 3.19)

--- a/lib/webhookdb/spec_helpers/http.rb
+++ b/lib/webhookdb/spec_helpers/http.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "puma"
+require "webmock"
+
+module Webhookdb::SpecHelpers::Http
+end
+
+module Webhookdb::SpecHelpers::Http::TestServer
+  class << self
+    def test_server_responses = @test_server_responses ||= []
+    def test_server_calls = @test_server_calls ||= []
+  end
+
+  def self.included(c)
+    test_server_port = nil
+    server_thread = nil
+    pserver = nil
+
+    c.let(:test_server) { pserver }
+    c.let(:test_server_port) { test_server_port }
+    c.let(:test_server_responses) { Webhookdb::SpecHelpers::Http::TestServer.test_server_responses }
+    c.let(:test_server_calls) { Webhookdb::SpecHelpers::Http::TestServer.test_server_calls }
+    c.let(:test_server_url) { "http://localhost:#{test_server_port}" }
+
+    c.before(:all) do
+      server = Class.new do
+        define_method(:call) do |env|
+          resp = Webhookdb::SpecHelpers::Http::TestServer.test_server_responses.pop
+          raise "must push to responses" if resp.nil?
+          Webhookdb::SpecHelpers::Http::TestServer.test_server_calls << env
+          resp = resp.call(env) if resp.respond_to?(:call)
+          return resp
+        end
+      end
+      pserver = Puma::Server.new(server.new)
+      tcp_server = pserver.add_tcp_listener("127.0.0.1", test_server_port)
+      test_server_port = tcp_server.addr[1]
+      server_thread = Thread.new do
+        pserver.run
+      end
+      # I don't think we need to sleep here but add it if needed.
+    end
+
+    c.after(:all) do
+      pserver&.stop(true)
+      server_thread&.join
+    end
+
+    c.before(:each) do
+      WebMock.allow_net_connect!
+      WebMock::HttpLibAdapters::HttpRbAdapter.disable!
+      Webhookdb::SpecHelpers::Http::TestServer.test_server_responses.clear
+      Webhookdb::SpecHelpers::Http::TestServer.test_server_calls.clear
+    end
+
+    c.after(:each) do
+      WebMock::HttpLibAdapters::HttpRbAdapter.enable!
+      WebMock.disable_net_connect!
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,7 @@ RSpec.configure do |config|
     config.include(Webhookdb::SpecHelpers)
     require "webhookdb/spec_helpers/async"
     config.include(Webhookdb::SpecHelpers::Async)
+    require "webhookdb/spec_helpers/http"
     require "webhookdb/spec_helpers/message"
     config.include(Webhookdb::SpecHelpers::Message)
     require "webhookdb/spec_helpers/postgres"


### PR DESCRIPTION
For a long time, we've been plagued by errors in Sentry due to errors when reading an HTTP body (not on the initial connection).

Now that we have an in-process http server for testing, I was able to reproduce this problem using some rack hijacking. This also meant removing Thin for Puma (thin doesn't support rack.hijack).

The fix was sort of obvious- wrapping the body-reading portion of the code in the same sort of exception handling that the initial connection uses.

Refactor the in-process http server into a spec helper module so it can be reused elsewhere.