### PR TITLE
Resilient fix; improve indices on table/opaqueid rename; use partition key more

### DIFF
--- a/lib/webhookdb/async/resilient_sidekiq_client.rb
+++ b/lib/webhookdb/async/resilient_sidekiq_client.rb
@@ -6,6 +6,8 @@ require "webhookdb/resilient_action"
 class Webhookdb::Async::ResilientSidekiqClient < Sidekiq::Client
   alias _native_raw_push raw_push
 
+  def __native_raw_push(*) = _native_raw_push(*)
+
   private def raw_push(payloads)
     Resilient.new(self).insert(payloads, {})
   end
@@ -26,12 +28,12 @@ class Webhookdb::Async::ResilientSidekiqClient < Sidekiq::Client
     def logger = Webhookdb::Async.logger
     def database_urls = Webhookdb::LoggedWebhook.available_resilient_database_urls
     def rescued_exception_types = [Redis::ConnectionError]
-    def do_insert(kwargs, _meta) = @client._native_raw_push(kwargs)
+    def do_insert(kwargs, _meta) = @client.__native_raw_push(kwargs)
     def table_name = Webhookdb::LoggedWebhook.resilient_jobs_table_name
     def ping = @client.redis_pool.with(&:ping)
 
     def do_replay(kwargs, _meta)
-      @client._native_raw_push(kwargs)
+      @client.__native_raw_push(kwargs)
     end
   end
 end

--- a/lib/webhookdb/replicator/fake.rb
+++ b/lib/webhookdb/replicator/fake.rb
@@ -426,7 +426,7 @@ class Webhookdb::Replicator::FakeStaleRowPartitioned < Webhookdb::Replicator::Fa
 
   def partition_method = Webhookdb::DBAdapter::Partitioning::HASH
   def partition_column_name = :textcol
-  def partition_value(r) = r.fetch("textcol")
+  def partition_key_from_resource(r) = self.partition_key_from_value(r.fetch("textcol"))
 end
 
 class Webhookdb::Replicator::FakeWithWatchChannel < Webhookdb::Replicator::Fake
@@ -456,7 +456,8 @@ class Webhookdb::Replicator::FakeHashPartition < Webhookdb::Replicator::Fake
 
   def partition_method = Webhookdb::DBAdapter::Partitioning::HASH
   def partition_column_name = :hashkey
-  def partition_value(resource) = self._str2inthash(resource.fetch("my_id"))
+  def partition_key_from_resource(resource) = self.partition_key_from_value(resource.fetch("my_id"))
+  def partition_key_from_value(v) = self._str2inthash(v)
 end
 
 class Webhookdb::Replicator::FakeRangePartition < Webhookdb::Replicator::Fake
@@ -466,5 +467,5 @@ class Webhookdb::Replicator::FakeRangePartition < Webhookdb::Replicator::Fake
 
   def partition_method = Webhookdb::DBAdapter::Partitioning::RANGE
   def partition_column_name = :at
-  def partition_value(resource) = resource.fetch("at")
+  def partition_key_from_resource(resource) = self.partition_key_from_value(resource.fetch("at"))
 end

--- a/lib/webhookdb/replicator/icalendar_event_v1_partitioned.rb
+++ b/lib/webhookdb/replicator/icalendar_event_v1_partitioned.rb
@@ -29,5 +29,6 @@ class Webhookdb::Replicator::IcalendarEventV1Partitioned < Webhookdb::Replicator
 
   def partition_method = Webhookdb::DBAdapter::Partitioning::HASH
   def partition_column_name = :calendar_external_hash
-  def partition_value(resource) = self._str2inthash(resource.fetch("calendar_external_id"))
+  def partition_key_from_resource(r) = self.partition_key_from_value(r.fetch("calendar_external_id"))
+  def partition_key_from_value(v) = self._str2inthash(v)
 end

--- a/lib/webhookdb/service_integration.rb
+++ b/lib/webhookdb/service_integration.rb
@@ -301,9 +301,9 @@ class Webhookdb::ServiceIntegration < Webhookdb::Postgres::Model(:service_integr
     return self.db.select(Sequel.function(:nextval, self.sequence_name)).single_value
   end
 
-  def new_opaque_id = Webhookdb::Id.new_opaque_id("svi")
+  def self.new_opaque_id = Webhookdb::Id.new_opaque_id("svi")
 
-  def ensure_opaque_id = self[:opaque_id] ||= self.new_opaque_id
+  def ensure_opaque_id = self[:opaque_id] ||= self.class.new_opaque_id
 
   def new_api_key
     k = +"sk/"

--- a/spec/webhookdb/organization_spec.rb
+++ b/spec/webhookdb/organization_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe "Webhookdb::Organization", :async, :db do
       oldtable = fake_sint.table_name
       newtable = oldtable + "_newname"
       oldid = fake_sint.opaque_id
-      newid = Webhookdb::Id.new_opaque_id("svi")
+      newid = Webhookdb::ServiceIntegration.new_opaque_id
       fake.admin_dataset do |ds|
         indexes = ds.from(:pg_indexes).where(tablename: oldtable).select_map(:indexname)
         expect(indexes).to have_length(3)

--- a/spec/webhookdb/replicator_spec.rb
+++ b/spec/webhookdb/replicator_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Webhookdb::Replicator, :db do
   end
 
   describe "refers_to_same_index?" do
-    opaqueid1 = Webhookdb::Id.new_opaque_id("svi")
-    opaqueid2 = Webhookdb::Id.new_opaque_id("svi")
+    opaqueid1 = Webhookdb::ServiceIntegration.new_opaque_id
+    opaqueid2 = Webhookdb::ServiceIntegration.new_opaque_id
 
     it "is true if the tables and indices are the same" do
       idx1 = Sequel[:t1][:idx]

--- a/spec/webhookdb/replicator_spec.rb
+++ b/spec/webhookdb/replicator_spec.rb
@@ -24,4 +24,39 @@ RSpec.describe Webhookdb::Replicator, :db do
       fake_path.unlink
     end
   end
+
+  describe "refers_to_same_index?" do
+    opaqueid1 = Webhookdb::Id.new_opaque_id("svi")
+    opaqueid2 = Webhookdb::Id.new_opaque_id("svi")
+
+    it "is true if the tables and indices are the same" do
+      idx1 = Sequel[:t1][:idx]
+      idx2 = Sequel[:t1][:idx]
+      expect(described_class.refers_to_same_index?(idx1, idx2)).to be(true)
+    end
+
+    it "is true if the tables and index names after the svi_ are the same" do
+      idx1 = Sequel[:t1][:"#{opaqueid1}_at_idx"]
+      idx2 = Sequel[:t1][:"#{opaqueid2}_at_idx"]
+      expect(described_class.refers_to_same_index?(idx1, idx2)).to be(true)
+    end
+
+    it "is false if the index names after the svi_ are different" do
+      idx1 = Sequel[:t1][:"#{opaqueid1}_at_idx"]
+      idx2 = Sequel[:t1][:"#{opaqueid2}_ta_idx"]
+      expect(described_class.refers_to_same_index?(idx1, idx2)).to be(false)
+    end
+
+    it "is false if the index names are different" do
+      idx1 = Sequel[:t1][:idx1]
+      idx2 = Sequel[:t1][:idx2]
+      expect(described_class.refers_to_same_index?(idx1, idx2)).to be(false)
+    end
+
+    it "is false if the table names are different, even if the index names are the same" do
+      idx1 = Sequel[:t1][:idx1]
+      idx2 = Sequel[:t2][:idx1]
+      expect(described_class.refers_to_same_index?(idx1, idx2)).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Use partition key for bulk operations

Some icalendar actions, like deleting obsolete recurring events
for a calendar, were not using the partition key.
Make them use it, and make it easier for other partitioned
replicators to use the partition key.

---

Add helper to align index names

When a service integration opaque id changes,
it is nice to be able to align index names to reflect
the new opaque id.

This is not necessary, as the routines now ignore differences
in opaque ids when searching for existing indices,
but it is nice to not have old names standing around.

---

Do not recreate indices when an opaque id changes

Changing a replicator opaque id would result in
new indices being built. This does an opaque-id
insensitive match on index names when figuring out
what indices need to be built during replication
migration and calculating 'create index' calls
during schema modifications.

---

Fix Resilient private method access

Not sure what's up with this yet. It caused one-time errors, but wasn't seen since. However, the non-`self.` `private` method access should be used regardless
