### PR TITLE
Improve partition indexing resilience

### DIFF
--- a/lib/webhookdb/postgres/maintenance.rb
+++ b/lib/webhookdb/postgres/maintenance.rb
@@ -22,16 +22,13 @@ module Webhookdb::Postgres::Maintenance
     end
 
     def conn_params
-      org_uri = URI(self.service_integration.organization.admin_connection_url_raw)
-      superuser_url = Webhookdb::Organization::DbBuilder.available_server_urls.find { |u| URI(u).host == org_uri.host }
-      raise Webhookdb::InvalidPrecondition, "cannot find superuser url for #{org_uri.host}" if superuser_url.nil?
-      sup_uri = URI(superuser_url)
+      sup_uri = URI(self.service_integration.organization.superuser_url_to_database!)
       return {
         user: sup_uri.user,
         password: sup_uri.password,
         host: sup_uri.host,
         port: sup_uri.port,
-        database: org_uri.path&.delete_prefix("/"),
+        database: sup_uri.path&.delete_prefix("/"),
         table: self.service_integration.table_name,
       }
     end


### PR DESCRIPTION
Indexing a partitioned table was problematic,
since it could fail and wasn't really idempotent.

This also fixes potential invalid indices when
migrating a non-partitioned table,
and in general should keep all indices tidy.

From the docs:

For partitioned tables, we need to be careful with how we create the indexes. If the overall function gets interrupted (the process gets killed, etc.), we can be left with an invalid index.
We can minimize this possibility by doing the following:
- Create an index for each partition, if it does not exist already.
  - This is done outside a transaction, since it may happen concurrently.
- Then we open a transaction for the final steps, which are all very fast/metadata-only.
  - A transaction here ensures that we only have the 'parent' index in a successful, completed state.
- Create the 'parent' index 'ONLY ON' the parent table.
  - This is a very fast operation.
- Attach all the partition indexes to the parent index. This is metadata-only so also very fast.
  - At this point, the parent index should be valid.
- These steps mean that, at any point, the process can be interrupted and resumed, without losing progress:
  - The concurrent index creation for the partitions can fail, and result in an invalid index; but the next call to update the schema will drop invalid indexes for the table. Note that successfully created, but unattached, indexes for a partition are valid.
  - The parent index creation, and attaching partitions to it, are atomic.