### PR TITLE
Keepalive false

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ PATH
       platform-api (~> 3.7)
       premailer (~> 1.27)
       pry (~> 0.15)
-      puma (~> 6.5)
+      puma (~> 6.6)
       rack-cors (~> 2.0)
       rack-protection (~> 3.2)
       rack-spa (~> 0.11)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -20,8 +20,6 @@ port ENV.fetch("PORT", nil)
 
 preload_app!
 
-enable_keep_alives false
-
 if workers_count.zero?
   Barnes.start
 else

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -20,6 +20,8 @@ port ENV.fetch("PORT", nil)
 
 preload_app!
 
+enable_keep_alives false
+
 if workers_count.zero?
   Barnes.start
 else

--- a/lib/webhookdb/sentry.rb
+++ b/lib/webhookdb/sentry.rb
@@ -10,9 +10,60 @@ module Webhookdb::Sentry
   include Appydays::Configurable
   include Appydays::Loggable
 
+  class << self
+    def traces_sampler(sampling_context)
+      return sampling_context[:parent_sampled] unless sampling_context[:parent_sampled].nil?
+      bias = self._get_specific_trace_rate(sampling_context)
+      rate = bias * self.traces_base_sample_rate
+      return rate
+    end
+
+    def _get_specific_trace_rate(sampling_context)
+      transaction_ctx = sampling_context[:transaction_context] || {}
+      if transaction_ctx[:op] == "http.server"
+        # env = sampling_context[:env] # Rack env
+        endpoint = transaction_ctx[:name] || ""
+        case endpoint
+          when "/healthz"
+            return self.traces_web_load_sample_rate * 0.1
+          when "/sink"
+            return 0
+          when %r{/v1/service_integrations/\w+$}, "/v1/install/front/intercom/webhook"
+            return self.traces_web_load_sample_rate
+          else
+            return self.traces_web_sample_rate
+        end
+      elsif transaction_ctx[:op] == "queue.process"
+        klass = transaction_ctx[:name] || "" # Sidekiq/Webhookdb::Jobs::SyncTargetRunSync
+        case klass
+          when "Sidekiq/Webhookdb::Async::AuditLogger",
+              "Sidekiq/Webhookdb::Jobs::IcalendarSync",
+              "Sidekiq/Webhookdb::Jobs::ProcessWebhook",
+              "Sidekiq/Amigo::Router"
+            return self.traces_job_load_sample_rate
+          else
+            return self.traces_job_sample_rate
+        end
+      end
+      return 1
+    end
+  end
+
   configurable(:sentry) do
     setting :dsn, ""
     setting :log_level, :warn
+    # Baseline all other trace configurations refer to.
+    # Turning this down will proportionately reduce all other traces.
+    setting :traces_base_sample_rate, 0.1
+    # Rate for most web requests, relative to base rate.
+    setting :traces_web_sample_rate, 1
+    # Rate for high-throughput "webhook" endpoints, like service integrations and 'install' calls,
+    # relative to base rate.
+    setting :traces_web_load_sample_rate, 0.05
+    # Rate for most jobs, relative to base rate.
+    setting :traces_job_sample_rate, 0.1
+    # Rate for high-throughput process webhook jobs, relative to base rate.
+    setting :traces_job_load_sample_rate, 0.05
 
     # Apply the current configuration to Sentry.
     # See https://docs.sentry.io/clients/ruby/config/ for more info.
@@ -24,6 +75,7 @@ module Webhookdb::Sentry
           config.dsn = dsn
           config.sdk_logger = self.logger
           config.sdk_logger.level = self.log_level
+          config.traces_sampler = ->(ctx) { self.traces_sampler(ctx) }
         end
       else
         Sentry.instance_variable_set(:@main_hub, nil)

--- a/lib/webhookdb/sentry.rb
+++ b/lib/webhookdb/sentry.rb
@@ -83,8 +83,13 @@ module Webhookdb::Sentry
           config.dsn = dsn
           config.sdk_logger = self.logger
           config.sdk_logger.level = self.log_level
-          config.traces_sampler = ->(ctx) { self.traces_sampler(ctx) }
+          if self.traces_base_sample_rate.zero?
+            config.traces_sample_rate = 0
+          else
+            config.traces_sampler = ->(ctx) { self.traces_sampler(ctx) }
+          end
         end
+        Sentry.configuration.sidekiq.propagate_traces = false
       else
         Sentry.instance_variable_set(:@main_hub, nil)
       end

--- a/lib/webhookdb/sentry.rb
+++ b/lib/webhookdb/sentry.rb
@@ -12,39 +12,47 @@ module Webhookdb::Sentry
 
   class << self
     def traces_sampler(sampling_context)
+      return 0 if self._skip_trace?(sampling_context)
       return sampling_context[:parent_sampled] unless sampling_context[:parent_sampled].nil?
       bias = self._get_specific_trace_rate(sampling_context)
       rate = bias * self.traces_base_sample_rate
       return rate
     end
 
+    SKIP_OPS = Set.new(["queue.publish", "db.redis"])
+    def _skip_trace?(sampling_context)
+      transaction_ctx = sampling_context[:transaction_context] || {}
+      return SKIP_OPS.include?(transaction_ctx[:op])
+    end
+
     def _get_specific_trace_rate(sampling_context)
       transaction_ctx = sampling_context[:transaction_context] || {}
-      if transaction_ctx[:op] == "http.server"
-        # env = sampling_context[:env] # Rack env
-        endpoint = transaction_ctx[:name] || ""
-        case endpoint
-          when "/healthz"
-            return self.traces_web_load_sample_rate * 0.1
-          when "/sink"
-            return 0
-          when %r{/v1/service_integrations/\w+$}, "/v1/install/front/intercom/webhook"
-            return self.traces_web_load_sample_rate
-          else
-            return self.traces_web_sample_rate
+      case transaction_ctx[:op]
+          when "http.server"
+            # env = sampling_context[:env] # Rack env
+            endpoint = transaction_ctx[:name] || ""
+            case endpoint
+              when "/healthz"
+                return self.traces_web_load_sample_rate * 0.1
+              when "/sink"
+                return 0
+              when %r{/v1/service_integrations/\w+$}, "/v1/install/front/intercom/webhook"
+                return self.traces_web_load_sample_rate
+              else
+                return self.traces_web_sample_rate
+            end
+          when "queue.process"
+            klass = transaction_ctx[:name] || "" # Sidekiq/Webhookdb::Jobs::SyncTargetRunSync
+            case klass
+              when "Sidekiq/Webhookdb::Async::AuditLogger",
+                  "Sidekiq/Webhookdb::Jobs::IcalendarSync",
+                  "Sidekiq/Webhookdb::Jobs::ProcessWebhook",
+                  "Sidekiq/Amigo::Router"
+                return self.traces_job_load_sample_rate
+              else
+                return self.traces_job_sample_rate
+            end
         end
-      elsif transaction_ctx[:op] == "queue.process"
-        klass = transaction_ctx[:name] || "" # Sidekiq/Webhookdb::Jobs::SyncTargetRunSync
-        case klass
-          when "Sidekiq/Webhookdb::Async::AuditLogger",
-              "Sidekiq/Webhookdb::Jobs::IcalendarSync",
-              "Sidekiq/Webhookdb::Jobs::ProcessWebhook",
-              "Sidekiq/Amigo::Router"
-            return self.traces_job_load_sample_rate
-          else
-            return self.traces_job_sample_rate
-        end
-      end
       return 1
     end
   end

--- a/spec/webhookdb/api/system_spec.rb
+++ b/spec/webhookdb/api/system_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe Webhookdb::API::System do
         redis: be_a(Float),
       )
     end
+
+    it "handles services that are down" do
+      expect(Webhookdb::Customer.db).to receive(:[]).and_raise(RuntimeError)
+      expect(Sidekiq).to receive(:redis).and_raise(RuntimeError)
+      get "/service_health"
+      expect(last_response).to have_status(200)
+      expect(last_response_json_body).to include(
+        autoscale_depth: -1,
+        autoscale_started: Time.at(0),
+        db: -1,
+        redis: -1,
+      )
+    end
   end
 
   describe "GET /statusz" do

--- a/spec/webhookdb/sentry_spec.rb
+++ b/spec/webhookdb/sentry_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Webhookdb::Sentry do
   end
 
   describe "trace sampling" do
+    let(:dsn) { "http://public:secret@not-really-sentry.nope/someproject" }
+
     before(:each) do
       described_class.reset_configuration(
         traces_base_sample_rate: 0.5,
@@ -52,6 +54,15 @@ RSpec.describe Webhookdb::Sentry do
         traces_job_sample_rate: 0.1,
         traces_job_load_sample_rate: 0.01,
       )
+    end
+
+    it "configures the trace sampler unless traces_base_sample_rate is 0" do
+      described_class.reset_configuration(dsn:, traces_base_sample_rate: 0)
+      expect(Sentry.configuration.traces_sample_rate).to eq(0)
+      expect(Sentry.configuration.traces_sampler).to be_nil
+      described_class.reset_configuration(dsn:, traces_base_sample_rate: 0.5)
+      expect(Sentry.configuration.traces_sample_rate).to be_nil
+      expect(Sentry.configuration.traces_sampler).to_not be_nil
     end
 
     it "uses the parent decision if available" do

--- a/spec/webhookdb/sentry_spec.rb
+++ b/spec/webhookdb/sentry_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe Webhookdb::Sentry do
       expect(described_class.traces_sampler(ctx)).to eq(0.5)
     end
 
+    it "skips certain ops" do
+      ctx = {parent_sampled: 0.8, transaction_context: {op: "queue.publish"}}
+      expect(described_class.traces_sampler(ctx)).to eq(0.0)
+    end
+
     describe "for web requests" do
       it "uses the web sample rate by default" do
         ctx = {transaction_context: {op: "http.server", name: "/foo"}}

--- a/webhookdb.gemspec
+++ b/webhookdb.gemspec
@@ -63,7 +63,7 @@ Gem::Specification.new do |s|
   s.add_dependency("platform-api", "~> 3.7")
   s.add_dependency("premailer", "~> 1.27")
   s.add_dependency("pry", "~> 0.15")
-  s.add_dependency("puma", "~> 6.5")
+  s.add_dependency("puma", "~> 6.6")
   s.add_dependency("rack-cors", "~> 2.0")
   s.add_dependency("rack-protection", "~> 3.2")
   s.add_dependency("rack-spa", "~> 0.11")


### PR DESCRIPTION
Add Sentry trace support.

Here's the config info:

```rb
    # Baseline all other trace configurations refer to.
    # Turning this down will proportionately reduce all other traces.
    setting :traces_base_sample_rate, 0.1
    # Rate for most web requests, relative to base rate.
    setting :traces_web_sample_rate, 1
    # Rate for high-throughput "webhook" endpoints, like service integrations and 'install' calls,
    # relative to base rate.
    setting :traces_web_load_sample_rate, 0.05
    # Rate for most jobs, relative to base rate.
    setting :traces_job_sample_rate, 0.1
    # Rate for high-throughput process webhook jobs, relative to base rate.
    setting :traces_job_load_sample_rate, 0.05
```