### PR TITLE
Cancel long-running jobs more nicely

### DIFF
--- a/lib/webhookdb/async.rb
+++ b/lib/webhookdb/async.rb
@@ -45,6 +45,10 @@ module Webhookdb::Async
     config[:dead_max_jobs] = 999_999_999
     config.server_middleware.add(Amigo::Retry::ServerMiddleware)
     config.server_middleware.add(Webhookdb::Async::TimeoutRetry::ServerMiddleware)
+
+    config.on(:quiet) do
+      self.sidekiq_shutting_down = true
+    end
   end
 
   def self._configure_client(config)
@@ -85,6 +89,12 @@ module Webhookdb::Async
       Sidekiq.configure_server { |config| self._configure_server(config) }
       Sidekiq.configure_client { |config| self._configure_client(config) }
     end
+  end
+
+  class << self
+    attr_writer :sidekiq_shutting_down
+
+    def stop_processing_jobs? = @sidekiq_shutting_down
   end
 
   def self.open_web

--- a/lib/webhookdb/async/job.rb
+++ b/lib/webhookdb/async/job.rb
@@ -3,20 +3,11 @@
 require "amigo/job"
 
 require "webhookdb/async"
+require "webhookdb/async/job_common"
 
 module Webhookdb::Async::Job
   def self.extended(cls)
     cls.extend Amigo::Job
-    cls.include(InstanceMethods)
-  end
-
-  module InstanceMethods
-    def with_log_tags(tags, &)
-      Webhookdb::Async::JobLogger.with_log_tags(tags, &)
-    end
-
-    def set_job_tags(tags)
-      Webhookdb::Async::JobLogger.set_job_tags(**tags)
-    end
+    cls.extend Webhookdb::Async::JobCommon
   end
 end

--- a/lib/webhookdb/async/job_common.rb
+++ b/lib/webhookdb/async/job_common.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "webhookdb/async"
+
+module Webhookdb::Async::JobCommon
+  def self.extended(cls)
+    cls.include(InstanceMethods)
+  end
+
+  module InstanceMethods
+    def with_log_tags(*tag, **tags, &)
+      tags.merge!(tag.first) if tag.any?
+      Webhookdb::Async::JobLogger.with_log_tags(tags, &)
+    end
+
+    def set_job_tags(*tag, **tags)
+      tags.merge!(tag.first) if tag.any?
+      Webhookdb::Async::JobLogger.set_job_tags(**tags)
+    end
+
+    def long_running_job_heartbeat!
+      raise Sidekiq::Shutdown if Webhookdb::Async.stop_processing_jobs?
+    end
+  end
+end

--- a/lib/webhookdb/async/scheduled_job.rb
+++ b/lib/webhookdb/async/scheduled_job.rb
@@ -3,20 +3,11 @@
 require "amigo/scheduled_job"
 
 require "webhookdb/async"
+require "webhookdb/async/job_common"
 
 module Webhookdb::Async::ScheduledJob
   def self.extended(cls)
     cls.extend Amigo::ScheduledJob
-    cls.include(InstanceMethods)
-  end
-
-  module InstanceMethods
-    def with_log_tags(tags, &)
-      Webhookdb::Async::JobLogger.with_log_tags(tags, &)
-    end
-
-    def set_job_tags(**tags)
-      Webhookdb::Async::JobLogger.set_job_tags(**tags)
-    end
+    cls.extend Webhookdb::Async::JobCommon
   end
 end

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
@@ -73,6 +73,7 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
             order(:pk).
             select(:external_id, :ics_url, :last_fetch_context)
           row_ds.paged_each(rows_per_fetch: 500, cursor_name: "ical_enqueue_#{sint.id}_cursor") do |row|
+            self.long_running_job_heartbeat!
             threadpool.post do
               break unless repl.feed_changed?(row)
               calendar_external_id = row.fetch(:external_id)


### PR DESCRIPTION
Sidekiq metrics are showing us long-running jobs.
These can be killed if they are running during Sidekiq shutdown. Much safer to interrupt long-running jobs and raise Sidekiq::Shutdown, so they will be re-enqueued when Sidekiq starts back up.

Also refactor common job code.
