### PR TITLE
Fix default max connections in web workers

### DIFF
--- a/lib/webhookdb/async.rb
+++ b/lib/webhookdb/async.rb
@@ -45,6 +45,10 @@ module Webhookdb::Async
     config[:dead_max_jobs] = 999_999_999
     config.server_middleware.add(Amigo::Retry::ServerMiddleware)
     config.server_middleware.add(Webhookdb::Async::TimeoutRetry::ServerMiddleware)
+
+    config.on(:quiet) do
+      self.sidekiq_shutting_down = true
+    end
   end
 
   def self._configure_client(config)
@@ -85,6 +89,12 @@ module Webhookdb::Async
       Sidekiq.configure_server { |config| self._configure_server(config) }
       Sidekiq.configure_client { |config| self._configure_client(config) }
     end
+  end
+
+  class << self
+    attr_writer :sidekiq_shutting_down
+
+    def stop_processing_jobs? = @sidekiq_shutting_down
   end
 
   def self.open_web

--- a/lib/webhookdb/async/job.rb
+++ b/lib/webhookdb/async/job.rb
@@ -3,20 +3,11 @@
 require "amigo/job"
 
 require "webhookdb/async"
+require "webhookdb/async/job_common"
 
 module Webhookdb::Async::Job
   def self.extended(cls)
     cls.extend Amigo::Job
-    cls.include(InstanceMethods)
-  end
-
-  module InstanceMethods
-    def with_log_tags(tags, &)
-      Webhookdb::Async::JobLogger.with_log_tags(tags, &)
-    end
-
-    def set_job_tags(tags)
-      Webhookdb::Async::JobLogger.set_job_tags(**tags)
-    end
+    cls.extend Webhookdb::Async::JobCommon
   end
 end

--- a/lib/webhookdb/async/job_common.rb
+++ b/lib/webhookdb/async/job_common.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "webhookdb/async"
+
+module Webhookdb::Async::JobCommon
+  def self.extended(cls)
+    cls.include(InstanceMethods)
+  end
+
+  module InstanceMethods
+    def with_log_tags(*tag, **tags, &)
+      tags.merge!(tag.first) if tag.any?
+      Webhookdb::Async::JobLogger.with_log_tags(tags, &)
+    end
+
+    def set_job_tags(*tag, **tags)
+      tags.merge!(tag.first) if tag.any?
+      Webhookdb::Async::JobLogger.set_job_tags(**tags)
+    end
+
+    def long_running_job_heartbeat!
+      raise Sidekiq::Shutdown if Webhookdb::Async.stop_processing_jobs?
+    end
+  end
+end

--- a/lib/webhookdb/async/scheduled_job.rb
+++ b/lib/webhookdb/async/scheduled_job.rb
@@ -3,20 +3,11 @@
 require "amigo/scheduled_job"
 
 require "webhookdb/async"
+require "webhookdb/async/job_common"
 
 module Webhookdb::Async::ScheduledJob
   def self.extended(cls)
     cls.extend Amigo::ScheduledJob
-    cls.include(InstanceMethods)
-  end
-
-  module InstanceMethods
-    def with_log_tags(tags, &)
-      Webhookdb::Async::JobLogger.with_log_tags(tags, &)
-    end
-
-    def set_job_tags(**tags)
-      Webhookdb::Async::JobLogger.set_job_tags(**tags)
-    end
+    cls.extend Webhookdb::Async::JobCommon
   end
 end

--- a/lib/webhookdb/concurrent.rb
+++ b/lib/webhookdb/concurrent.rb
@@ -53,13 +53,13 @@ module Webhookdb::Concurrent
       super()
       threads ||= queue_size
       @timeout = timeout
+      @queue = Thread::SizedQueue.new(queue_size)
+      @exception = nil
       @threads = (1..threads).map do
         Thread.new do
           loop { break unless self.do_work }
         end
       end
-      @queue = Thread::SizedQueue.new(queue_size)
-      @exception = nil
     end
 
     protected def do_work

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
@@ -73,6 +73,7 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
             order(:pk).
             select(:external_id, :ics_url, :last_fetch_context)
           row_ds.paged_each(rows_per_fetch: 500, cursor_name: "ical_enqueue_#{sint.id}_cursor") do |row|
+            self.long_running_job_heartbeat!
             threadpool.post do
               break unless repl.feed_changed?(row)
               calendar_external_id = row.fetch(:external_id)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,17 +12,19 @@ require "simplecov-cobertura"
 (SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter) if ENV["CI"]
 SimpleCov.start if ENV["CI"] || ENV["COVERAGE"]
 
+require "rspec"
+
+require "appydays/configurable/spec_helpers"
+require "appydays/loggable/spec_helpers"
+require "appydays/spec_helpers"
+require "dotenv/autorestore"
 require "httparty"
 require "rack/test"
 require "rack/test/methods"
-require "rspec"
 require "rspec/eventually"
 require "rspec/json_expectations"
 require "timecop"
 require "webmock/rspec"
-require "appydays/spec_helpers"
-require "appydays/configurable/spec_helpers"
-require "appydays/loggable/spec_helpers"
 
 require "webhookdb"
 require "webhookdb/spec_helpers"
@@ -32,7 +34,8 @@ Webhookdb.load_app
 Webhookdb::Fixtures.load_all
 
 RSpec.configure do |config|
-  config.full_backtrace = true
+  # Set this in .env.test.local if you want to show full error messages
+  config.full_backtrace = ENV.fetch("RSPEC_FULL_BACKTRACE", nil) ? true : false
 
   RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 3000
 

--- a/spec/webhookdb/dbutil_spec.rb
+++ b/spec/webhookdb/dbutil_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe Webhookdb::Dbutil, :db do
+  describe "configuration", reset_configuration: described_class do
+    before(:each) do
+      ENV["SIDEKIQ_CONCURRENCY"] = "51"
+      ENV["RAILS_MAX_THREADS"] = "52"
+    end
+
+    describe "max connections" do
+      it "uses SIDEKIQ_CONCURRENCY if PROC_MODE is sidekiq" do
+        ENV["PROC_MODE"] = "sidekiq"
+        described_class.reset_configuration
+        expect(described_class.max_connections).to eq(51)
+      end
+
+      it "uses RAILS_MAX_THREADS concurrency if PROC_MODE is puma" do
+        ENV["PROC_MODE"] = "puma"
+        described_class.reset_configuration
+        expect(described_class.max_connections).to eq(52)
+      end
+
+      it "uses an explicit DBUTIL_MAX_CONNECTIONS if set" do
+        ENV["PROC_MODE"] = "puma"
+        ENV["DBUTIL_MAX_CONNECTIONS"] = "83"
+        described_class.reset_configuration
+        expect(described_class.max_connections).to eq(83)
+      end
+
+      it "uses a default concurrency otherwise" do
+        described_class.reset_configuration
+        expect(described_class.max_connections).to eq(4)
+      end
+
+      it "adds DBUTIL_ADDITONAL_POOL_SIZE to max connections" do
+        described_class.reset_configuration(additional_pool_size: 10)
+        expect(described_class.max_connections).to eq(14)
+
+        ENV["PROC_MODE"] = "sidekiq"
+        described_class.reset_configuration(additional_pool_size: 10)
+        expect(described_class.max_connections).to eq(61)
+
+        ENV["PROC_MODE"] = "puma"
+        described_class.reset_configuration(additional_pool_size: 10)
+        expect(described_class.max_connections).to eq(62)
+      end
+
+      it "errors if max_connections is 0 or negative" do
+        ENV["DBUTIL_MAX_CONNECTIONS"] = "0"
+        expect do
+          described_class.reset_configuration(max_connection: 0)
+        end.to raise_error(/max_connections is misconfigured/)
+      end
+    end
+  end
+end

--- a/spec/webhookdb/redis_spec.rb
+++ b/spec/webhookdb/redis_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe Webhookdb::Redis do
   describe "#fetch_url" do
     let(:envname) { "_WHDBTEST_REDIS_URL" }
 
-    after(:each) do
-      ENV.delete(envname)
-    end
-
     it "returns the url if not blank" do
       expect(described_class.fetch_url(envname, "x")).to eq("x")
     end
@@ -37,8 +33,6 @@ RSpec.describe Webhookdb::Redis do
       ENV["HEROKU_APP_ID"] = "a1b2bc"
       expect(described_class.conn_params(ssl_schema_url)).to include(ssl_params: {verify_mode: 0})
       expect(described_class.conn_params(none_ssl_schema_url)).to_not include(:ssl_params)
-    ensure
-      ENV.delete("HEROKU_APP_ID")
     end
   end
 

--- a/spec/webhookdb_spec.rb
+++ b/spec/webhookdb_spec.rb
@@ -7,12 +7,10 @@ require "webhookdb"
 RSpec.describe Webhookdb do
   describe "configuration" do
     before(:each) do
-      @env = ENV.fetch(described_class::CONFIG_ENV_VAR, nil)
       @tempfiles = []
     end
 
     after(:each) do
-      ENV[described_class::CONFIG_ENV_VAR] = @end
       @tempfiles.each { |t| t.close(true) }
     end
 


### PR DESCRIPTION
The max threads in the pool was set to WEB_CONCURRENCY,
which is the number of processes, NOT the number of threads.
We should use RAILS_MAX_THREADS as the pool size instead.

Also add tests for dbutil configuration.

Should fix issues with slow web response times and pool timeouts.
