### PR TITLE
Add long running job heartbeats

### DIFF
--- a/lib/webhookdb/async.rb
+++ b/lib/webhookdb/async.rb
@@ -95,6 +95,14 @@ module Webhookdb::Async
     attr_writer :sidekiq_shutting_down
 
     def stop_processing_jobs? = @sidekiq_shutting_down
+
+    # Call this in long-running jobs.
+    # Raises +Sidekiq::Shutdown+ if we're trying to shut down.
+    # Emits an +Amigo::DurableJob+ heartbeat if enabled.
+    def long_running_job_heartbeat!
+      raise Sidekiq::Shutdown if self.stop_processing_jobs?
+      Amigo::DurableJob.heartbeat
+    end
   end
 
   def self.open_web

--- a/lib/webhookdb/async/job_common.rb
+++ b/lib/webhookdb/async/job_common.rb
@@ -17,9 +17,5 @@ module Webhookdb::Async::JobCommon
       tags.merge!(tag.first) if tag.any?
       Webhookdb::Async::JobLogger.set_job_tags(**tags)
     end
-
-    def long_running_job_heartbeat!
-      raise Sidekiq::Shutdown if Webhookdb::Async.stop_processing_jobs?
-    end
   end
 end

--- a/lib/webhookdb/backfiller.rb
+++ b/lib/webhookdb/backfiller.rb
@@ -24,7 +24,7 @@ class Webhookdb::Backfiller
       page.each do |item|
         self.handle_item(item)
       end
-      Amigo::DurableJob.heartbeat
+      Webhookdb::Async.long_running_job_heartbeat!
       break if pagination_token.blank?
       if Webhookdb.regression_mode?
         Webhookdb.logger.warn("regression_mode_backfill_termination", backfiller: self.to_s, pagination_token:)
@@ -97,6 +97,7 @@ class Webhookdb::Backfiller
     def flush_pending_inserts
       return if self.dry_run?
       return if self.pending_inserts.empty?
+      Webhookdb::Async.long_running_job_heartbeat!
       rows_to_insert = self.pending_inserts.values
       update_where_expr = self.update_where_expr
       update_expr = self.upserting_replicator._upsert_update_expr(rows_to_insert.first)

--- a/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
+++ b/lib/webhookdb/jobs/icalendar_enqueue_syncs.rb
@@ -73,7 +73,7 @@ class Webhookdb::Jobs::IcalendarEnqueueSyncs
             order(:pk).
             select(:external_id, :ics_url, :last_fetch_context)
           row_ds.paged_each(rows_per_fetch: 500, cursor_name: "ical_enqueue_#{sint.id}_cursor") do |row|
-            self.long_running_job_heartbeat!
+            Webhookdb::Async.long_running_job_heartbeat!
             threadpool.post do
               break unless repl.feed_changed?(row)
               calendar_external_id = row.fetch(:external_id)

--- a/lib/webhookdb/organization/database_migration.rb
+++ b/lib/webhookdb/organization/database_migration.rb
@@ -98,7 +98,7 @@ class Webhookdb::Organization::DatabaseMigration < Webhookdb::Postgres::Model(:o
       if chunk.size >= chunksize
         self.upsert_chunk(service_integration, dstdb, chunk)
         chunk.clear
-        Amigo::DurableJob.heartbeat
+        Webhookdb::Async.long_running_job_heartbeat!
       end
     end
     self.upsert_chunk(service_integration, dstdb, chunk)

--- a/lib/webhookdb/replicator/base_stale_row_deleter.rb
+++ b/lib/webhookdb/replicator/base_stale_row_deleter.rb
@@ -135,6 +135,7 @@ class Webhookdb::Replicator::BaseStaleRowDeleter
       window_end = window_start + self.incremental_lookback_size
       inner_ds = base_ds.where(self.updated_at_column => window_start..window_end)
       loop do
+        Webhookdb::Async.long_running_job_heartbeat!
         # See note above about why we only use the LIMIT and inner query in unpartitioned tables.
         delete_ds = self.replicator.partition? ? inner_ds : ds.where(pk: inner_ds)
         # Disable seqscan for the delete. We can end up with seqscans if the planner decides

--- a/lib/webhookdb/sync_target.rb
+++ b/lib/webhookdb/sync_target.rb
@@ -553,6 +553,7 @@ class Webhookdb::SyncTarget < Webhookdb::Postgres::Model(:sync_targets)
     end
 
     def _flush_http_chunk(chunk_started, chunk)
+      Webhookdb::Async.long_running_job_heartbeat!
       chunk_ts = chunk.last.fetch(self.replicator.timestamp_column.name)
       @mutex.synchronize do
         @inflight_timestamps << chunk_ts


### PR DESCRIPTION
Any long-running jobs should heartbeat to check if sidekiq is going to be shut down, so they can be canceled.

Also call DurableJob.heartbeat, since it seems reasonable to make this a one-stop-job for long-running jobs.
