### PR TITLE
Procmon: Monitor Redis and Sidekiq

### DIFF
--- a/lib/webhookdb/procmon.rb
+++ b/lib/webhookdb/procmon.rb
@@ -15,10 +15,13 @@ class Webhookdb::Procmon
   configurable(:procmon) do
     setting :enabled, true
     setting :interval, 60
-    # At what disk usage percentage should be alert.
+    # At what disk usage percentage should we alert.
     setting :disk_threshold_pct, 70
     # What mount path should we detect disk usage percentage for.
     setting :mount_path, Dir.pwd
+    # At what memory usage percentage should we alert.
+    # '60' would alert above 600MB used on a 1GB server.
+    setting :redis_memory_pct, 60
     setting :info_log_level, :info
     setting :warn_log_level, :warn
   end
@@ -37,7 +40,16 @@ class Webhookdb::Procmon
     end
 
     def check
+      self.prepare
       checkdisk
+      checkredis
+      level = @alerted ? self.warn_log_level : self.info_log_level
+      self.logger.send(level, "procmon", @logtags)
+    end
+
+    def prepare
+      @logtags = {}
+      @alerted = false
     end
 
     def checkdisk
@@ -52,33 +64,63 @@ class Webhookdb::Procmon
       disk_used = blocks_used * stat.block_size
       # disk_free = stat.blocks_free - stat.block_size
       disk_total = stat.blocks * stat.block_size
-      disk_perc_used = ((disk_used / disk_total.to_f) * 100).to_i
+      disk_perc_used = ((disk_used / disk_total.to_f) * 100).round
       # disk_perc_free = stat.blocks_free * stat.block_size
       files_used = stat.files - stat.files_available
-      files_perc_used = ((files_used / stat.files.to_f) * 100).to_i
+      files_perc_used = ((files_used / stat.files.to_f) * 100).round
+      @logtags.merge!(
+        disk_used:,
+        disk_perc_used:,
+        files_used:,
+        files_perc_used:,
+      )
       is_alert = disk_perc_used > self.disk_threshold_pct || files_perc_used > self.disk_threshold_pct
-      if is_alert
-        fields = [
+      return unless is_alert
+      self.devalert(
+        "Disk",
+        ":file_folder:",
+        [
           {title: "Disk Used", value: "#{disk_used.to_f.to_gb.round(1)} GB"},
           {title: "Disk % Used", value: "#{disk_perc_used}%"},
           {title: "Files Used", value: files_used},
           {title: "Files % Used", value: "#{files_perc_used}%"},
-        ]
-        Webhookdb::DeveloperAlert.new(
-          subsystem: "Process Monitor",
-          emoji: ":file_folder:",
-          fallback: fields.
-            map { |f| "#{f[:title]}: #{f[:value]}" }.
-            join(", "),
-          fields:,
-        ).emit
-      end
-      level = is_alert ? self.warn_log_level : self.info_log_level
-      self.logger.send(level, "procmon",
-                       disk_used:,
-                       disk_perc_used:,
-                       files_used:,
-                       files_perc_used:,)
+        ],
+      )
+    end
+
+    def checkredis
+      meminfo = ::Amigo::MemoryPressure.instance.get_memory_info
+      maxmemory = meminfo.fetch("maxmemory").to_i
+      avail_mem = maxmemory.zero? ? meminfo.fetch("total_system_memory").to_i : maxmemory
+      used_mem = meminfo.fetch("used_memory").to_i
+      perc_used_mem = ((used_mem.to_f / avail_mem) * 100).round
+      is_alert = perc_used_mem > self.redis_memory_pct
+      @logtags[:redis_used_memory] = used_mem
+      @logtags[:redis_memory_pct] = perc_used_mem
+      return unless is_alert
+      avail_mem_human = meminfo.fetch(maxmemory.zero? ? "total_system_memory_human" : "maxmemory_human")
+      self.devalert(
+        "Redis",
+        ":key:",
+        [
+          {title: "Used Memory", value: meminfo.fetch("used_memory_human")},
+          {title: "Used Memory RSS", value: meminfo.fetch("used_memory_rss_human")},
+          {title: "Available Memory", value: avail_mem_human},
+          {title: "Peak Memory", value: meminfo.fetch("used_memory_peak_human")},
+        ],
+      )
+    end
+
+    private def devalert(subsystem, emoji, fields)
+      @alerted = true
+      Webhookdb::DeveloperAlert.new(
+        subsystem: "Process Monitor (#{subsystem})",
+        emoji:,
+        fields:,
+        fallback: fields.
+          map { |f| "#{f[:title]}: #{f[:value]}" }.
+          join(", "),
+      ).emit
     end
   end
 end

--- a/spec/webhookdb/procmon_spec.rb
+++ b/spec/webhookdb/procmon_spec.rb
@@ -13,59 +13,129 @@ RSpec.describe Webhookdb::Procmon do
     described_class.reset_configuration
   end
 
-  it "logs disk usage" do
-    described_class.mount_path = "/app"
-    stat = Sys::Filesystem::Stat.new
-    stat.blocks = 1000
-    stat.blocks_free = 900
-    stat.block_size = 1024
-    stat.files = 1000
-    stat.files_available = 800
-    expect(Sys::Filesystem).to receive(:stat).with("/app").and_return(stat)
-    logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
-      described_class.check
+  describe "check", :async do
+    it "logs disk usage" do
+      described_class.mount_path = "/app"
+      stat = Sys::Filesystem::Stat.new
+      stat.blocks = 1000
+      stat.blocks_free = 900
+      stat.block_size = 1024
+      stat.files = 1000
+      stat.files_available = 800
+      expect(Sys::Filesystem).to receive(:stat).with("/app").and_return(stat)
+      logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
+        expect do
+          described_class.check
+        end.to_not publish("webhookdb.developeralert.emitted")
+      end
+      expect(logs).to have_a_line_matching(/"message":"procmon"/)
+      expect(logs).to have_a_line_matching(
+        /"disk_used":102400,"disk_perc_used":10,"files_used":200,"files_perc_used":20/,
+      )
     end
-    expect(logs).to have_a_line_matching(/"message":"procmon"/)
-    expect(logs).to have_a_line_matching(
-      /"disk_used":102400,"disk_perc_used":10,"files_used":200,"files_perc_used":20/,
-    )
-  end
 
-  it "warns on high disk usage", :async do
-    described_class.mount_path = "/app"
-    stat = Sys::Filesystem::Stat.new
-    stat.blocks = 1_000_000
-    stat.blocks_free = 100_000
-    stat.block_size = 4096
-    stat.files = 1000
-    stat.files_available = 50
-    expect(Sys::Filesystem).to receive(:stat).with("/app").and_return(stat).twice
-    logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
-      described_class.check
+    it "warns on high disk usage" do
+      described_class.mount_path = "/app"
+      stat = Sys::Filesystem::Stat.new
+      stat.blocks = 1_000_000
+      stat.blocks_free = 100_000
+      stat.block_size = 4096
+      stat.files = 1000
+      stat.files_available = 50
+      expect(Sys::Filesystem).to receive(:stat).with("/app").and_return(stat).twice
+      logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
+        described_class.check
+      end
+      expect(logs).to have_a_line_matching(/"message":"procmon"/)
+      expect(logs).to have_a_line_matching(
+        /"disk_used":3686400000,"disk_perc_used":90,"files_used":950,"files_perc_used":95/,
+      )
+
+      expect do
+        described_class.check
+      end.to publish("webhookdb.developeralert.emitted").with_payload(
+        contain_exactly(
+          {
+            "subsystem" => "Process Monitor (Disk)",
+            "emoji" => ":file_folder:",
+            "fallback" => "Disk Used: 3.4 GB, Disk % Used: 90%, Files Used: 950, Files % Used: 95%",
+            "fields" => [
+              {"title" => "Disk Used", "value" => "3.4 GB"},
+              {"title" => "Disk % Used", "value" => "90%"},
+              {"title" => "Files Used", "value" => 950},
+              {"title" => "Files % Used", "value" => "95%"},
+
+            ],
+          },
+        ),
+      )
     end
-    expect(logs).to have_a_line_matching(/"message":"procmon"/)
-    expect(logs).to have_a_line_matching(
-      /"disk_used":3686400000,"disk_perc_used":90,"files_used":950,"files_perc_used":95/,
-    )
 
-    expect do
-      described_class.check
-    end.to publish("webhookdb.developeralert.emitted").with_payload(
-      contain_exactly(
-        {
-          "subsystem" => "Process Monitor",
-          "emoji" => ":file_folder:",
-          "fallback" => "Disk Used: 3.4 GB, Disk % Used: 90%, Files Used: 950, Files % Used: 95%",
-          "fields" => [
-            {"title" => "Disk Used", "value" => "3.4 GB"},
-            {"title" => "Disk % Used", "value" => "90%"},
-            {"title" => "Files Used", "value" => 950},
-            {"title" => "Files % Used", "value" => "95%"},
+    it "logs Redis memory usage" do
+      expect(Amigo::MemoryPressure.instance).to receive(:get_memory_info).
+        and_return({"maxmemory" => "1073741824", "used_memory" => "417452392"})
+      logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
+        expect do
+          described_class.check
+        end.to_not publish("webhookdb.developeralert.emitted")
+      end
+      expect(logs).to have_a_line_matching(/"message":"procmon"/)
+      expect(logs).to have_a_line_matching(
+        /"redis_used_memory":417452392,"redis_memory_pct":39/,
+      )
+    end
 
-          ],
-        },
-      ),
-    )
+    it "uses total memory if maxmemory is 0" do
+      expect(Amigo::MemoryPressure.instance).to receive(:get_memory_info).
+        and_return({
+                     "maxmemory" => "0",
+                     "used_memory" => "973741824",
+                     "used_memory_human" => "900MB",
+                     "total_system_memory" => "1073741824",
+                     "total_system_memory_human" => "1GB",
+                     "used_memory_rss_human" => "901MBMB",
+                     "used_memory_peak_human" => "902MB",
+                   })
+      logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
+        expect do
+          described_class.check
+        end.to publish("webhookdb.developeralert.emitted")
+      end
+      expect(logs).to have_a_line_matching(/"message":"procmon"/)
+      expect(logs).to have_a_line_matching(
+        /"redis_used_memory":973741824,"redis_memory_pct":91/,
+      )
+    end
+
+    it "warns on high Redis memory usage" do
+      expect(Amigo::MemoryPressure.instance).to receive(:get_memory_info).
+        and_return({
+                     "maxmemory" => "1000000",
+                     "maxmemory_human" => "1GB",
+                     "used_memory" => "800000",
+                     "used_memory_human" => "800MB",
+                     "used_memory_rss_human" => "805MB",
+                     "used_memory_peak_human" => "810MB",
+                   })
+
+      expect do
+        described_class.check
+      end.to publish("webhookdb.developeralert.emitted").with_payload(
+        contain_exactly(
+          {
+            "subsystem" => "Process Monitor (Redis)",
+            "emoji" => ":key:",
+            "fallback" => "Used Memory: 800MB, Used Memory RSS: 805MB, Available Memory: 1GB, Peak Memory: 810MB",
+            "fields" => [
+              {"title" => "Used Memory", "value" => "800MB"},
+              {"title" => "Used Memory RSS", "value" => "805MB"},
+              {"title" => "Available Memory", "value" => "1GB"},
+              {"title" => "Peak Memory", "value" => "810MB"},
+            ],
+          },
+        ),
+      )
+    end
   end
 
   it "polls in a thread, and exits when shutting down" do


### PR DESCRIPTION
We have recently been seeing stuck jobs (probably IcalendarSync) that are not slow, and do not appear stuck in 3rd party requests, but something is keeping them from finishing. It could be related to Heroku's Router 2.0 changes and the calls to icalproxy, but it's unclear. The stuck jobs happen all at once- we go from no stuck jobs, to many stuck jobs, relatively quickly, and it isn't related to the feed itself (some of these have been processing for months/years, and are small).

This adds monitoring so we 1) know about long-running jobs before they saturate our workers, and 2) alert about Redis memory pressure before becoming OOM, which makes this issue very hard to diagnose. Then maybe we can get to the cause of the stuck job itself.