### PR TITLE
Use timeouts when calling icalendar urls

### DIFF
--- a/lib/webhookdb/icalendar.rb
+++ b/lib/webhookdb/icalendar.rb
@@ -43,5 +43,10 @@ module Webhookdb::Icalendar
     # Api key of the icalproxy server, if using one.
     # See https://github.com/webhookdb/icalproxy
     setting :proxy_api_key, ""
+
+    # Because some ical files can be several megabytes, and on all sorts of servers,
+    # provide separate connect (also used for write) and read timeouts.
+    setting :http_connect_timeout, 30
+    setting :http_read_timeout, 30
   end
 end

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -271,7 +271,16 @@ The secret to use for signing is:
       headers["Authorization"] = "Apikey #{Webhookdb::Icalendar.proxy_api_key}" if
         Webhookdb::Icalendar.proxy_api_key.present?
     end
-    resp = Webhookdb::Http.chunked_download(request_url, headers:)
+    resp = Webhookdb::Http.chunked_download(
+      request_url,
+      headers:,
+      logger: self.logger,
+      timeout: {
+        connect: Webhookdb::Icalendar.http_connect_timeout,
+        write: Webhookdb::Icalendar.http_connect_timeout,
+        read: Webhookdb::Icalendar.http_read_timeout,
+      },
+    )
     return resp
   end
 


### PR DESCRIPTION
We were calling icalendar urls (usually icalproxy) without a timeout. This was an oversight, possibly removed when the chunked download was rewritten a while ago.
This could result in hung clients.
See https://github.com/webhookdb/icalproxy/pull/6

Ideally we will get errors reported if there are server problems, rather than a bunch of hung workers.

It is of course still possible that we'll get hung workers, but hopefully not!
