### PR TITLE
Improve startup and COW memory usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "ice_cube", git: "https://github.com/nehresma/ice_cube.git", ref: "d7ea51efc
 group :test do
   gem "faker", "~> 3.2"
   gem "fluent_fixtures", "~> 0.11"
+  gem "memory_profiler", "~> 1.1"
   gem "rack-test", "~> 2.1"
   gem "rspec", "~> 3.12"
   gem "rspec-eventually", "~> 0.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ PATH
       slack-notifier (~> 2.4)
       stripe (~> 15.2)
       sys-filesystem (~> 1.5)
+      sys-memory (~> 0.2)
       uuidx (~> 0.10)
       warden (~> 1.2)
 
@@ -241,6 +242,7 @@ GEM
       net-imap
       net-pop
       net-smtp
+    memory_profiler (1.1.0)
     method_source (1.1.0)
     mimemagic (0.4.3)
       nokogiri (~> 1)
@@ -429,6 +431,8 @@ GEM
     strscan (3.1.5)
     sys-filesystem (1.5.3)
       ffi (~> 1.1)
+    sys-memory (0.2.0)
+      ffi (~> 1.1)
     timecop (0.9.10)
     timeout (0.4.3)
     tzinfo (2.0.6)
@@ -457,6 +461,7 @@ DEPENDENCIES
   faker (~> 3.2)
   fluent_fixtures (~> 0.11)
   ice_cube!
+  memory_profiler (~> 1.1)
   rack-test (~> 2.1)
   rspec (~> 3.12)
   rspec-eventually (~> 0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,6 @@ PATH
       slack-notifier (~> 2.4)
       stripe (~> 15.2)
       sys-filesystem (~> 1.5)
-      sys-memory (~> 0.2)
       uuidx (~> 0.10)
       warden (~> 1.2)
 
@@ -430,8 +429,6 @@ GEM
     stripe (15.2.1)
     strscan (3.1.5)
     sys-filesystem (1.5.3)
-      ffi (~> 1.1)
-    sys-memory (0.2.0)
       ffi (~> 1.1)
     timecop (0.9.10)
     timeout (0.4.3)

--- a/lib/webhookdb.rb
+++ b/lib/webhookdb.rb
@@ -254,6 +254,7 @@ module Webhookdb
   end
 end
 
+require "webhookdb/async"
 require "webhookdb/dbutil"
 require "webhookdb/developer_alert"
 require "webhookdb/http"

--- a/lib/webhookdb/apps.rb
+++ b/lib/webhookdb/apps.rb
@@ -56,7 +56,7 @@ module Webhookdb::Apps
     Webhookdb::Async.setup_web
     config_ru.instance_exec do
       map "/admin_api" do
-        run Webhookdb::Apps::AdminAPI.build_app
+        run Webhookdb::Apps::AdminAPI.build_app(compile: true)
       end
       map "/admin" do
         run Webhookdb::Apps::Admin.to_app
@@ -71,7 +71,7 @@ module Webhookdb::Apps
         memo[k] = v
         memo["#{k}/"] = v
       end)
-      run Webhookdb::Apps::API.build_app
+      run Webhookdb::Apps::API.build_app(compile: true)
     end
   end
 

--- a/lib/webhookdb/async.rb
+++ b/lib/webhookdb/async.rb
@@ -10,16 +10,15 @@ require "sentry-sidekiq"
 require "sidekiq"
 require "sidekiq-cron"
 
-require "webhookdb"
 require "webhookdb/redis"
+
+module Webhookdb::Async; end
 
 module Webhookdb::Async
   include Appydays::Configurable
   include Appydays::Loggable
-  extend Webhookdb::MethodUtilities
 
   require "webhookdb/async/job_logger"
-  require "webhookdb/async/audit_logger"
 
   def self._configure_server(config)
     require "amigo/job_in_context"

--- a/lib/webhookdb/procmon.rb
+++ b/lib/webhookdb/procmon.rb
@@ -4,6 +4,7 @@ require "appydays/configurable"
 require "appydays/loggable"
 require "sys/filesystem"
 
+require "webhookdb/developer_alert"
 require "webhookdb/signals"
 
 # Basic monitor for things like disk space, in environments that don't have other monitors for it,
@@ -24,7 +25,7 @@ class Webhookdb::Procmon
     # '60' would alert above 600MB used on a 1GB server.
     setting :redis_memory_pct, 60
     # Alert about jobs which have been running for longer than this number of seconds (default 2 hours).
-    setting :long_running_jobs_age, 2.hours.to_i
+    setting :long_running_jobs_age, 2 * 60 * 60
     # Only alert when there are more than this many long-running jobs.
     # It is hard to avoid *all* long-running jobs, and the occassional long job can be managed through metrics.
     # But we want to alert if we end up becoming saturated with long-running jobs.

--- a/lib/webhookdb/redis.rb
+++ b/lib/webhookdb/redis.rb
@@ -3,6 +3,8 @@
 require "appydays/configurable"
 require "redis_client"
 
+require "webhookdb/dbutil"
+
 module Webhookdb::Redis
   include Appydays::Configurable
 

--- a/lib/webhookdb/service/helpers.rb
+++ b/lib/webhookdb/service/helpers.rb
@@ -23,21 +23,21 @@ module Webhookdb::Service::Helpers
   # Return the currently-authenticated user,
   # or respond with a 401 if there is no authenticated user.
   def current_customer
-    return _check_customer_deleted(env["warden"].authenticate!(scope: :customer), admin_customer?)
+    return _check_customer_deleted(env["warden"]&.authenticate!(scope: :customer), admin_customer?)
   end
 
   # Return the currently-authenticated user,
   # or respond nil if there is no authenticated user.
   def current_customer?
-    return _check_customer_deleted(env["warden"].user(scope: :customer), admin_customer?)
+    return _check_customer_deleted(env["warden"]&.user(scope: :customer), admin_customer?)
   end
 
   def admin_customer
-    return _check_customer_deleted(env["warden"].authenticate!(scope: :admin), nil)
+    return _check_customer_deleted(env["warden"]&.authenticate!(scope: :admin), nil)
   end
 
   def admin_customer?
-    return _check_customer_deleted(env["warden"].authenticate(scope: :admin), nil)
+    return _check_customer_deleted(env["warden"]&.authenticate(scope: :admin), nil)
   end
 
   def authenticate!

--- a/spec/webhookdb/procmon_spec.rb
+++ b/spec/webhookdb/procmon_spec.rb
@@ -4,7 +4,10 @@ require "webhookdb/procmon"
 
 RSpec.describe Webhookdb::Procmon do
   before(:each) do
-    described_class.reset_configuration
+    described_class.reset_configuration(singleton_hostname_regex: /.*/)
+    ENV["DYNO"] = "web1"
+    # We don't know the memory usage of the system we're running on, so never cause a false positive during tests.
+    allow(Sys::Memory).to receive(:load).and_return(1)
     Webhookdb::SHUTTING_DOWN.make_false
     Webhookdb::SHUTTING_DOWN_EVENT.reset
   end
@@ -57,14 +60,58 @@ RSpec.describe Webhookdb::Procmon do
         contain_exactly(
           {
             "subsystem" => "Process Monitor (Disk)",
-            "emoji" => ":file_folder:",
-            "fallback" => "Disk Used: 3.4 GB, Disk % Used: 90%, Files Used: 950, Files % Used: 95%",
+            "emoji" => ":dvd:",
+            "fallback" => "Host: web1, Disk Used: 3.4 GB, Disk % Used: 90%, Files Used: 950, Files % Used: 95%",
             "fields" => [
+              {"title" => "Host", "value" => "web1", "short" => true},
               {"title" => "Disk Used", "value" => "3.4 GB", "short" => true},
               {"title" => "Disk % Used", "value" => "90%", "short" => true},
               {"title" => "Files Used", "value" => "950", "short" => true},
               {"title" => "Files % Used", "value" => "95%", "short" => true},
 
+            ],
+          },
+        ),
+      )
+    end
+
+    it "logs memory usage" do
+      expect(Sys::Memory).to receive(:used).and_return(123_456_789)
+      expect(Sys::Memory).to receive(:load).and_return(45)
+      logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
+        expect do
+          described_class.check
+        end.to_not publish("webhookdb.developeralert.emitted")
+      end
+      expect(logs).to have_a_line_matching(/"message":"procmon"/)
+      expect(logs).to have_a_line_matching(
+        /"mem_used":123456789,"mem_perc_used":45/,
+      )
+    end
+
+    it "warns on high memory usage" do
+      expect(Sys::Memory).to receive(:used).and_return(123_456_789).twice
+      expect(Sys::Memory).to receive(:load).and_return(99).twice
+      logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
+        described_class.check
+      end
+      expect(logs).to have_a_line_matching(/"message":"procmon"/)
+      expect(logs).to have_a_line_matching(
+        /"mem_used":123456789,"mem_perc_used":99/,
+      )
+
+      expect do
+        described_class.check
+      end.to publish("webhookdb.developeralert.emitted").with_payload(
+        contain_exactly(
+          {
+            "subsystem" => "Process Monitor (Memory)",
+            "emoji" => ":brain:",
+            "fallback" => "Host: web1, Memory Used: 0.1 GB, Memory % Used: 99%",
+            "fields" => [
+              {"title" => "Host", "value" => "web1", "short" => true},
+              {"title" => "Memory Used", "value" => "0.1 GB", "short" => true},
+              {"title" => "Memory % Used", "value" => "99%", "short" => true},
             ],
           },
         ),
@@ -214,6 +261,27 @@ RSpec.describe Webhookdb::Procmon do
           ),
         )
       end
+    end
+
+    it "does not run singleton checks if the host name does not match the regex (DYNO env var)" do
+      described_class.reset_configuration(singleton_hostname_regex: /web\.1/)
+      ENV["DYNO"] = "web.2"
+
+      logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
+        described_class.check
+      end
+      expect(logs).to_not have_a_line_matching(/sidekiq_running_jobs/)
+    end
+
+    it "does not run singleton checks if the host name does not match the regex (Socket.hostname)" do
+      described_class.reset_configuration(singleton_hostname_regex: /web\.1/)
+      ENV.delete("DYNO")
+      expect(Socket).to receive(:gethostname).and_return("web.2")
+
+      logs = capture_logs_from(described_class.logger, level: :info, formatter: :json) do
+        described_class.check
+      end
+      expect(logs).to_not have_a_line_matching(/sidekiq_running_jobs/)
     end
   end
 

--- a/spec/webhookdb/service_spec.rb
+++ b/spec/webhookdb/service_spec.rb
@@ -209,6 +209,16 @@ RSpec.describe Webhookdb::Service, :db do
     expect(last_response).to have_status(301)
   end
 
+  it "can precompile the app" do
+    uncompiled = Class.new(described_class)
+    uncompiled.build_app
+    expect(uncompiled.instance).to be_nil
+
+    compiled = Class.new(described_class)
+    compiled.build_app(compile: true)
+    expect(compiled.instance).to_not be_nil
+  end
+
   it "always clears request_user after the request" do
     Thread.current[:request_user] = 5
     Thread.current[:request_admin] = 6

--- a/webhookdb.gemspec
+++ b/webhookdb.gemspec
@@ -89,6 +89,7 @@ Gem::Specification.new do |s|
   s.add_dependency("slack-notifier", "~> 2.4")
   s.add_dependency("stripe", "~> 15.2")
   s.add_dependency("sys-filesystem", "~> 1.5")
+  s.add_dependency("sys-memory", "~> 0.2")
   s.add_dependency("uuidx", "~> 0.10")
   s.add_dependency("warden", "~> 1.2")
 end

--- a/webhookdb.gemspec
+++ b/webhookdb.gemspec
@@ -89,7 +89,6 @@ Gem::Specification.new do |s|
   s.add_dependency("slack-notifier", "~> 2.4")
   s.add_dependency("stripe", "~> 15.2")
   s.add_dependency("sys-filesystem", "~> 1.5")
-  s.add_dependency("sys-memory", "~> 0.2")
   s.add_dependency("uuidx", "~> 0.10")
   s.add_dependency("warden", "~> 1.2")
 end


### PR DESCRIPTION
Procmon: Add singleton check

Only run singleton (sidekiq, redis) checks on a host that matches a regex. Avoids duplicate warnings.

---

Improve startup memory usage

Pre-warm Puma/Grape better by making a mock request
to each app, which will load code in memory before forking.

Also fix some require order problems.