### PR TITLE
ICal: recurring event edge case, and more timezone handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby "3.4.4"
 gemspec
 
 # Pull in BYPOS ICal rule fix from https://github.com/ice-cube-ruby/ice_cube/pull/449
-gem "ice_cube", git: "https://github.com/nehresma/ice_cube.git", ref: "d7ea51efcd"
+gem "ice_cube", git: "https://github.com/nehresma/ice_cube.git", ref: "1674659380"
 
 # NOTE: When running integration tests, you will need to set BUNDLE_WITHOUT to something other than 'test'.
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/nehresma/ice_cube.git
-  revision: d7ea51efcdb06b3d6f8ccc9f940893103a6f568f
-  ref: d7ea51efcd
+  revision: 1674659380ccc6342df1fcc53b339e9259f5d306
+  ref: 1674659380
   specs:
-    ice_cube (0.16.4)
+    ice_cube (0.17.0)
 
 PATH
   remote: .

--- a/lib/webhookdb/replicator/icalendar_calendar_v1.rb
+++ b/lib/webhookdb/replicator/icalendar_calendar_v1.rb
@@ -480,10 +480,13 @@ The secret to use for signing is:
         candidates = @expanded_events_by_uid[uid]
         if candidates.nil?
           # We can have no recurring events, even with the exclusion date.
-          # Not much we can do here- just treat it as a standalone event.
+          # Not much we can do here. Just treat it as a standalone event.
+          # NOTE: recurring_event_id is nil because we have no series we're a part of.
           yield h
           return
         end
+        # This is some type of series, so record the series it came from.
+        h["recurring_event_id"] = uid
         unless (match = candidates.find { |c| c[startfield] == start })
           # There are some providers (like Apple) where an excluded event
           # will be outside the bounds of the RRULE of its owner.
@@ -494,7 +497,6 @@ The secret to use for signing is:
           # So increment the last-seen sequence number for the UID and use that.
           max_seq_num = @max_sequence_num_by_uid[uid] += 1
           h["UID"] = {"v" => "#{uid}-#{max_seq_num}"}
-          h["recurring_event_id"] = uid
           h["recurring_event_sequence"] = max_seq_num
           yield h
           return


### PR DESCRIPTION
Handle more weird timezones

Windows with trailing digits, empty, and digit-only
(should have already been handled).

---

recurring id not set on some ical events

One of the code paths for recurring event edge cases
did not set the recurring_event_id.
This would cause the event to later be deleted when
cleaning up rows no longer relevant to the event.